### PR TITLE
Fix URL building bug

### DIFF
--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -361,13 +361,16 @@ public class ClientApi {
         sb.append('/');
         if (params != null) {
             sb.append('?');
+	    String amp = "";
             for (Map.Entry<String, String> p : params.entrySet()) {
+		sb.append(amp);
                 sb.append(encodeQueryParam(p.getKey()));
                 sb.append('=');
                 if (p.getValue() != null) {
                     sb.append(encodeQueryParam(p.getValue()));
                 }
-                sb.append('&');
+                //sb.append('&');
+		amp="&";    
             }
         }
 


### PR DESCRIPTION
Any call to the buildZapRequestUrl function with 'params' causes the function to return a URL with an extra ampersand ('&') appended to the end. This leads to http error 400 - Bad Request Error. 

The reason this happens is that the ampersand is appended to every map entry in the params Map, including the last one. 

This PR fixes this issue. It is based on the accepted answer to this question
http://stackoverflow.com/questions/3395286/remove-last-character-of-a-stringbuilder 
and is an elegant solution.

Note: I didn't seem to able to raise an issue first, so I decided to send a PR directly.