### PR TITLE
Add task to verify artifacts' binary compatibility

### DIFF
--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -1,8 +1,12 @@
+plugins {
+    id "me.champeau.gradle.japicmp" version "0.1.2"
+}
 
 apply plugin: 'maven'
 apply plugin: 'signing'
 
 version '1.1.0-SNAPSHOT'
+ext.versionBC = '1.0.0'
 
 dependencies { compile 'org.jdom:jdom:1.1.3' }
 
@@ -15,6 +19,14 @@ jar {
         'Main-Class': 'org.zaproxy.clientapi.core.ClientApiMain',
         'Create-Date': new Date().format("yyyy-MM-dd")
     }
+}
+
+task japicmp(dependsOn: jar, type: me.champeau.gradle.ArtifactJapicmpTask) {
+    baseline = "${project.group}:${project.name}:${versionBC}@jar"
+    to = jar.archivePath
+    onlyBinaryIncompatibleModified = true
+    failOnModification = true
+    htmlOutputFile = file("$buildDir/reports/japi.html")
 }
 
 task javadocJar(type: Jar) {


### PR DESCRIPTION
Add a task to verify the binary compatibility of new artifacts, against
version 1.0.0.
