### PR TITLE
Allow to obtain all data of an ApiResponseSet

### DIFF
--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseSet.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseSet.java
@@ -17,44 +17,128 @@
  */
 package org.zaproxy.clientapi.core;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.w3c.dom.Node;
 
 public class ApiResponseSet extends ApiResponse {
 	
 	private String[] attributes = null;
-	private Map<String, String> values = null;
+	private final Map<String, String> valuesMap;
 
+	/**
+	 * Constructs an {@code ApiResponseSet} with the given name and attributes.
+	 *
+	 * @param name the name of the API response
+	 * @param attributes the attributes
+	 * @deprecated (TODO add version) Unused, there's no replacement.
+	 */
+	@Deprecated
 	public ApiResponseSet(String name, String[] attributes) {
 		super(name);
 		this.attributes = attributes;
+		this.valuesMap = Collections.emptyMap();
 	}
 
 	public ApiResponseSet(String name, Map<String, String> values) {
 		super(name);
-		this.values = values;
+		this.valuesMap = Collections.unmodifiableMap(new HashMap<>(values));
 	}
 
 	public ApiResponseSet(Node node) throws ClientApiException {
 		super(node.getNodeName());
 		Node child = node.getFirstChild();
-		this.values = new HashMap<String, String>();
+		Map<String, String> values = new HashMap<>();
 		while (child != null) {
 			ApiResponseElement elem = (ApiResponseElement) ApiResponseFactory.getResponse(child);
 			values.put(elem.getName(), elem.getValue());
 			child = child.getNextSibling();
 		}
+		this.valuesMap = Collections.unmodifiableMap(values);
 	}
 
+	/**
+	 * Gets the attributes.
+	 *
+	 * @return the attributes, might be {@code null}.
+	 * @deprecated (TODO add version) Unused, there's no replacement.
+	 * @see #getValues()
+	 */
+	@Deprecated
 	public String[] getAttributes() {
 		return attributes;
 	}
 	
-	public String getAttribute(String name) {
-		return this.values.get(name);
+	/**
+	 * Gets the value for the given {@code key}.
+	 *
+	 * @param key the key of the value
+	 * @return the value, or {@code null} if no value exists for the given {@code key}.
+	 * @deprecated (TODO add version) Use {@link #getValue(String)} instead.
+	 */
+	@Deprecated
+	public String getAttribute(String key) {
+		return getValue(key);
+	}
+
+	/**
+	 * Gets the value for the given {@code key}.
+	 *
+	 * @param key the key of the value
+	 * @return the value, or {@code null} if no value exists for the given {@code key}.
+	 * @since TODO add version
+	 * @see #getKeys()
+	 */
+	public String getValue(String key) {
+		return valuesMap.get(key);
+	}
+
+	/**
+	 * Gets a {@code Map} with the keys and values.
+	 * <p>
+	 * The returned {@code Map} is unmodifiable, any attempt to modify it will result in an
+	 * {@code UnsupportedOperationException}.
+	 *
+	 * @return the map with the keys/values, never {@code null}.
+	 * @since TODO add version
+	 */
+	public Map<String, String> getValuesMap() {
+		return valuesMap;
+	}
+
+	/**
+	 * Gets the keys of the values.
+	 * <p>
+	 * The returned {@code Set} is unmodifiable, any attempt to modify it will result in an
+	 * {@code UnsupportedOperationException}.
+	 *
+	 * @return the keys, never {@code null}.
+	 * @since TODO add version
+	 * @see #getValue(String)
+	 * @see #getValues()
+	 * @see #getValuesMap()
+	 */
+	public Set<String> getKeys() {
+		return valuesMap.keySet();
+	}
+
+	/**
+	 * Gets the values.
+	 * <p>
+	 * The returned {@code Collection} is unmodifiable, any attempt to modify it will result in an
+	 * {@code UnsupportedOperationException}.
+	 *
+	 * @return the values, never {@code null}.
+	 * @since TODO add version
+	 * @see #getValue(String)
+	 */
+	public Collection<String> getValues() {
+		return valuesMap.values();
 	}
 
 	@Override
@@ -66,7 +150,7 @@ public class ApiResponseSet extends ApiResponse {
 		sb.append("ApiResponseSet ");
 		sb.append(this.getName());
 		sb.append(" : [\n");
-		for (Entry<String, String> val  : values.entrySet()) {
+		for (Entry<String, String> val  : valuesMap.entrySet()) {
 			for (int i=0 ; i < indent+1; i++) {
 				sb.append("\t");
 			}


### PR DESCRIPTION
Change ApiResponseSet to allow to obtain the keys, values and the map.
Deprecate unused method and constructor.
 ---
From talks in IRC.

Version was not bumped, per changes in #4.