### PR TITLE
Remove usage of deprecated method

### DIFF
--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
@@ -79,8 +79,8 @@ public class FormBasedAuthentication {
 
 			for (ApiResponse r : configParamsList.getItems()) {
 				ApiResponseSet set = (ApiResponseSet) r;
-				System.out.println("'" + methodName + "' config param: " + set.getAttribute("name") + " ("
-						+ (set.getAttribute("mandatory").equals("true") ? "mandatory" : "optional") + ")");
+				System.out.println("'" + methodName + "' config param: " + set.getValue("name") + " ("
+						+ (set.getValue("mandatory").equals("true") ? "mandatory" : "optional") + ")");
 			}
 		}
 	}
@@ -95,8 +95,8 @@ public class FormBasedAuthentication {
 		StringBuilder sb = new StringBuilder("Users' config params: ");
 		for (ApiResponse r : configParamsList.getItems()) {
 			ApiResponseSet set = (ApiResponseSet) r;
-			sb.append(set.getAttribute("name")).append(" (");
-			sb.append((set.getAttribute("mandatory").equals("true") ? "mandatory" : "optional"));
+			sb.append(set.getValue("name")).append(" (");
+			sb.append((set.getValue("mandatory").equals("true") ? "mandatory" : "optional"));
 			sb.append("), ");
 		}
 		System.out.println(sb.deleteCharAt(sb.length() - 2).toString());

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -192,19 +192,19 @@ public class ClientApi {
             for (ApiResponse resp : alertList.getItems()) {
             	ApiResponseSet alertSet = (ApiResponseSet)resp;
                 alerts.add(new Alert(
-                		alertSet.getAttribute("alert"),
-                        alertSet.getAttribute("url"),
-                        Risk.valueOf(alertSet.getAttribute("risk")),
-                        Confidence.valueOf(alertSet.getAttribute("confidence")),
-                        alertSet.getAttribute("param"),
-                        alertSet.getAttribute("other"),
-                        alertSet.getAttribute("attack"),
-                        alertSet.getAttribute("description"),
-                        alertSet.getAttribute("reference"),
-                        alertSet.getAttribute("solution"),
-                        alertSet.getAttribute("evidence"),
-                        Integer.parseInt(alertSet.getAttribute("cweid")),
-                        Integer.parseInt(alertSet.getAttribute("wascid"))));
+                		alertSet.getValue("alert"),
+                        alertSet.getValue("url"),
+                        Risk.valueOf(alertSet.getValue("risk")),
+                        Confidence.valueOf(alertSet.getValue("confidence")),
+                        alertSet.getValue("param"),
+                        alertSet.getValue("other"),
+                        alertSet.getValue("attack"),
+                        alertSet.getValue("description"),
+                        alertSet.getValue("reference"),
+                        alertSet.getValue("solution"),
+                        alertSet.getValue("evidence"),
+                        Integer.parseInt(alertSet.getValue("cweid")),
+                        Integer.parseInt(alertSet.getValue("wascid"))));
             }
         }
     	return alerts;


### PR DESCRIPTION
Replace the calls of ApiResponseSet.getAttribute(String) with
getValue(String), which should have been done at the same time of the
deprecation.

Related to #5 - Allow to obtain all data of an ApiResponseSet