### PR TITLE
Skip archive signing if there's no signing key

### DIFF
--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -54,7 +54,11 @@ task uberJar(type: Jar) {
 
 artifacts { archives sourcesJar, javadocJar }
 
-signing { sign configurations.archives }
+signing {
+    if (project.hasProperty('signing.keyId')) {
+        sign configurations.archives
+    }
+}
 
 uploadArchives {
     repositories {


### PR DESCRIPTION
Change signing task to skip archive signing if there's no signing key ID
defined.