### PR TITLE
Add plugin to check vulns of dependencies

### DIFF
--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -1,9 +1,11 @@
 plugins {
     id "me.champeau.gradle.japicmp" version "0.1.2"
+    id "org.owasp.dependencycheck" version "1.4.4.1"
 }
 
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'org.owasp.dependencycheck'
 
 version '1.1.0-SNAPSHOT'
 ext.versionBC = '1.0.0'


### PR DESCRIPTION
Add OWASP Dependency-Check plugin to check the publicly disclosed
vulnerabilities of the dependencies being used by ZAP API client.