### PR TITLE
Use same version for both artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ allprojects {
     apply plugin: 'java'
     group = 'org.zaproxy'
 
+    version '1.1.0-SNAPSHOT'
+    ext.versionBC = '1.0.0'
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/subprojects/zap-clientapi-ant/zap-clientapi-ant.gradle
+++ b/subprojects/zap-clientapi-ant/zap-clientapi-ant.gradle
@@ -1,6 +1,4 @@
 
-version '1.0.1-SNAPSHOT'
-
 dependencies {
     compile project(':zap-clientapi')
     compileOnly 'org.apache.ant:ant:1.9.7'

--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -5,9 +5,6 @@ plugins {
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-version '1.1.0-SNAPSHOT'
-ext.versionBC = '1.0.0'
-
 dependencies { compile 'org.jdom:jdom:1.1.3' }
 
 sourceSets { examples }


### PR DESCRIPTION
Use the same version for both Java API client and Ant tasks, as both
artifacts are maintained and released at the same time.