### PR TITLE
Allow to specify the API key through the ClientApi

### DIFF
--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
@@ -37,12 +37,13 @@ public class SimpleExample {
     private static final String TARGET = "http://localhost:8080/bodgeit/";
 
     public static void main(String[] args) {
-        ClientApi api = new ClientApi(ZAP_ADDRESS, ZAP_PORT);
+        ClientApi api = new ClientApi(ZAP_ADDRESS, ZAP_PORT, ZAP_API_KEY);
 
         try {
             // Start spidering the target
             System.out.println("Spider : " + TARGET);
-            ApiResponse resp = api.spider.scan(ZAP_API_KEY, TARGET, null, null, null, null);
+            // It's not necessary to pass the ZAP API key again, already set when creating the ClientApi.
+            ApiResponse resp = api.spider.scan(null, TARGET, null, null, null, null);
             String scanid;
             int progress;
 
@@ -64,7 +65,7 @@ public class SimpleExample {
             Thread.sleep(2000);
 
             System.out.println("Active scan : " + TARGET);
-            resp = api.ascan.scan(ZAP_API_KEY, TARGET, "True", "False", null, null, null);
+            resp = api.ascan.scan(null, TARGET, "True", "False", null, null, null);
 
             // The scan now returns a scan id to support concurrent scanning
             scanid = ((ApiResponseElement) resp).getValue();
@@ -81,7 +82,7 @@ public class SimpleExample {
             System.out.println("Active Scan complete");
 
             System.out.println("Alerts:");
-            System.out.println(new String(api.core.xmlreport(ZAP_API_KEY)));
+            System.out.println(new String(api.core.xmlreport(null)));
 
         } catch (Exception e) {
             System.out.println("Exception : " + e.getMessage());


### PR DESCRIPTION
Change ClientApi to allow to specify the ZAP API key when creating the
instance, to ensure that the API key is sent with all API requests.
Also, send it in the header not just as (query) parameter (for newer and
older versions of ZAP).
Update SimpleExample to indicate the new usage.

Related to zaproxy/zaproxy#3226 - Option to supply API key or nonces via
header