### PR TITLE
Allow to specify the API key in all Ant tasks

### DIFF
--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
@@ -24,12 +24,11 @@ import org.apache.tools.ant.BuildException;
 public class ActiveScanSubtreeTask extends ZapTask {
 	
 	private String url;
-	private String apikey;
 	
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().ascan.scan(apikey, url, "true", "false", "", "", "");
+			this.getClientApi().ascan.scan(null, url, "true", "false", "", "", "");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);
@@ -42,13 +41,5 @@ public class ActiveScanSubtreeTask extends ZapTask {
 
 	public void setUrl(String url) {
 		this.url = url;
-	}
-
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanUrlTask.java
@@ -24,12 +24,11 @@ import org.apache.tools.ant.BuildException;
 public class ActiveScanUrlTask extends ZapTask {
 	
 	private String url;
-	private String apikey;
 
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().ascan.scan(apikey, url, "false", "false", "", "", "");
+			this.getClientApi().ascan.scan(null, url, "false", "false", "", "", "");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);
@@ -42,13 +41,5 @@ public class ActiveScanUrlTask extends ZapTask {
 
 	public void setUrl(String url) {
 		this.url = url;
-	}
-
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/LoadSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/LoadSessionTask.java
@@ -24,12 +24,11 @@ import org.apache.tools.ant.BuildException;
 public class LoadSessionTask extends ZapTask {
 	
 	private String name;
-	private String apikey;
 
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.loadSession(apikey, name);
+			this.getClientApi().core.loadSession(null, name);
 			
 		} catch (Exception e) {
 			throw new BuildException(e);
@@ -42,13 +41,5 @@ public class LoadSessionTask extends ZapTask {
 
 	public void setName(String name) {
 		this.name = name;
-	}
-	
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/NewSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/NewSessionTask.java
@@ -24,12 +24,11 @@ import org.apache.tools.ant.BuildException;
 public class NewSessionTask extends ZapTask {
 	
 	private String name;
-	private String apikey;
 
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.newSession(apikey, name, "true");
+			this.getClientApi().core.newSession(null, name, "true");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);
@@ -42,13 +41,5 @@ public class NewSessionTask extends ZapTask {
 
 	public void setName(String name) {
 		this.name = name;
-	}
-	
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SaveSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SaveSessionTask.java
@@ -24,12 +24,11 @@ import org.apache.tools.ant.BuildException;
 public class SaveSessionTask extends ZapTask {
 	
 	private String name;
-	private String apikey;
 
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.saveSession(apikey, name, "true");
+			this.getClientApi().core.saveSession(null, name, "true");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);
@@ -42,13 +41,5 @@ public class SaveSessionTask extends ZapTask {
 
 	public void setName(String name) {
 		this.name = name;
-	}
-
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
@@ -24,12 +24,11 @@ import org.apache.tools.ant.BuildException;
 public class SpiderUrlTask extends ZapTask {
 	
 	private String url;
-	private String apikey;
 
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().spider.scan(apikey, url, "", "", null, null);
+			this.getClientApi().spider.scan(null, url, "", "", null, null);
 			
 		} catch (Exception e) {
 			throw new BuildException(e);
@@ -44,12 +43,4 @@ public class SpiderUrlTask extends ZapTask {
 		this.url = url;
 	}
 
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
-	}
-	
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
@@ -23,24 +23,14 @@ import org.apache.tools.ant.BuildException;
 
 public class StopZapTask extends ZapTask {
 	
-	private String apikey;
-	
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.shutdown(apikey);
+			this.getClientApi().core.shutdown(null);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new BuildException(e);
 		}
 	}
 
-	public String getApikey() {
-		return apikey;
-	}
-
-	public void setApikey(String apikey) {
-		this.apikey = apikey;
-	}
-	
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ZapTask.java
@@ -26,9 +26,10 @@ public abstract class ZapTask extends Task {
 	private String zapAddress;
 	private int zapPort;
 	private boolean debug = false;
+	private String apikey;
 	
 	protected ClientApi getClientApi() {
-		return new ClientApi(zapAddress, zapPort, debug);
+		return new ClientApi(zapAddress, zapPort, apikey, debug);
 	}
 
 	public String getZapAddress() {
@@ -50,5 +51,13 @@ public abstract class ZapTask extends Task {
 
 	public void setDebug(boolean debug) {
 		this.debug = debug;
+	}
+
+	public String getApikey() {
+		return apikey;
+	}
+
+	public void setApikey(String apikey) {
+		this.apikey = apikey;
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/test/java/org/zaproxy/clientapi/ant/BuildTest.java
+++ b/subprojects/zap-clientapi-ant/src/test/java/org/zaproxy/clientapi/ant/BuildTest.java
@@ -1,0 +1,154 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.ant;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.BuildFileRule;
+import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+import fi.iki.elonen.NanoHTTPD;
+
+/**
+ * Tests that the tasks accept the expected attributes and nested elements.
+ */
+public class BuildTest {
+
+    private static final String BUILD_FILE_NAME = "build.xml";
+    private static final String BUILD_FILE_PATH = BuildTest.class.getResource(BUILD_FILE_NAME).toString().replace("file:", "");
+
+    private static SimpleServer zap;
+    private static SimpleServer targetSite;
+
+    @Rule
+    public final BuildFileRule buildRule = new BuildFileRule();
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        zap = new SimpleServer(
+                "text/xml; charset=UTF-8",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><response>OK</response>");
+
+        targetSite = new SimpleServer("text/plain", "");
+    }
+
+    @Before
+    public void setUpBuildFile() {
+        buildRule.configureProject(BUILD_FILE_PATH);
+
+        // Properties used in build.xml file
+        buildRule.getProject().setProperty("zap.addr", "localhost");
+        buildRule.getProject().setProperty("zap.port", Integer.toString(zap.getListeningPort()));
+        buildRule.getProject().setProperty("zap.key", "API_KEY");
+        buildRule.getProject().setProperty("zap.targetUrl", "http://localhost:" + targetSite.getListeningPort());
+        buildRule.getProject().setProperty("zap.session", "session");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (zap != null) {
+            zap.stop();
+        }
+
+        if (targetSite != null) {
+            targetSite.stop();
+        }
+    }
+
+    @Test
+    public void shouldExecuteTargetAccessUrl() {
+        buildRule.executeTarget("accessUrl");
+    }
+
+    @Test
+    public void shouldExecuteTargetActiveScanSubtree() {
+        buildRule.executeTarget("activeScanSubtree");
+    }
+
+    @Test
+    public void shouldExecuteTargetActiveScanUrl() {
+        buildRule.executeTarget("activeScanUrl");
+    }
+
+    @Test
+    public void shouldExecuteTargetAlertCheck() {
+        try {
+            buildRule.executeTarget("alertCheck");
+        } catch (BuildException e) {
+            assertTrue(e.getCause() instanceof ClientApiException);
+            assertTrue(e.getCause().getMessage().startsWith("Not found 1 alerts"));
+        }
+    }
+
+    @Test
+    public void shouldExecuteTargetLoadSession() {
+        buildRule.executeTarget("loadSession");
+    }
+
+    @Test
+    public void shouldExecuteTargetNewSession() {
+        buildRule.executeTarget("newSession");
+    }
+
+    @Test
+    public void shouldExecuteTargetSaveSession() {
+        buildRule.executeTarget("saveSession");
+    }
+
+    @Test
+    public void shouldExecuteTargetSpider() {
+        buildRule.executeTarget("spider");
+    }
+
+    @Test
+    public void shouldExecuteTargetStopZap() {
+        buildRule.executeTarget("stopZap");
+    }
+
+    private static class SimpleServer extends NanoHTTPD {
+
+        private final String mimeType;
+        private final String response;
+
+        public SimpleServer(String mimeType, String response) throws IOException {
+            super(0);
+            start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+
+            this.mimeType = mimeType;
+            this.response = response;
+        }
+
+        @Override
+        public Response serve(IHTTPSession session) {
+            return new Response(Response.Status.OK, mimeType, new StringInputStream(response), response.length()) {
+                // Extend to access the constructor.
+            };
+        }
+    }
+}

--- a/subprojects/zap-clientapi-ant/src/test/resources/org/zaproxy/clientapi/ant/build.xml
+++ b/subprojects/zap-clientapi-ant/src/test/resources/org/zaproxy/clientapi/ant/build.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="ant-tests">
+
+	<taskdef name="accessUrlTask" classname="org.zaproxy.clientapi.ant.AccessUrlTask" />
+	<taskdef name="activeScanSubtreeTask" classname="org.zaproxy.clientapi.ant.ActiveScanSubtreeTask" />
+	<taskdef name="activeScanUrlTask" classname="org.zaproxy.clientapi.ant.ActiveScanUrlTask" />
+	<taskdef name="alertCheckTask" classname="org.zaproxy.clientapi.ant.AlertCheckTask" />
+	<taskdef name="loadSessionTask" classname="org.zaproxy.clientapi.ant.LoadSessionTask" />
+	<taskdef name="newSessionTask" classname="org.zaproxy.clientapi.ant.NewSessionTask" />
+	<taskdef name="saveSessionTask" classname="org.zaproxy.clientapi.ant.SaveSessionTask" />
+	<taskdef name="spiderUrlTask" classname="org.zaproxy.clientapi.ant.SpiderUrlTask" />
+	<taskdef name="stopZapTask" classname="org.zaproxy.clientapi.ant.StopZapTask" />
+
+	<target name="accessUrl">
+		<accessUrlTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" url="${zap.targetUrl}" />
+	</target>
+
+	<target name="activeScanSubtree">
+		<activeScanSubtreeTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" url="${zap.targetUrl}" />
+	</target>
+
+	<target name="activeScanUrl">
+		<activeScanUrlTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" url="${zap.targetUrl}" />
+	</target>
+
+	<target name="alertCheck">
+		<alertCheckTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}">
+			<ignoreAlert name="Alert 1" risk="Informational" confidence="FalsePositive" url="URL" param="Param 1" other="Other Info" />
+			<ignoreAlert name="Alert 2" risk="Low" confidence="Low" url="URL" param="Param 2" other="Other Info" />
+			<ignoreAlert name="Alert 3" risk="Medium" confidence="Medium" url="URL" param="Param 3" other="Other Info" />
+			<ignoreAlert name="Alert 4" risk="High" confidence="High" url="URL" param="Param 4" other="Other Info" />
+			<ignoreAlert name="Alert 5" confidence="Confirmed" url="URL" param="Param 5" other="Other Info" />
+			<requireAlert name="Alert 6" confidence="Confirmed" url="URL" param="Param 6" other="Other Info" />
+
+			<!-- Check deprecated attributes alert and reliability -->
+			<ignoreAlert alert="Alert 7" reliability="Warning" />
+			<ignoreAlert alert="Alert 8" reliability="Suspicious" />
+		</alertCheckTask>
+	</target>
+
+	<target name="loadSession">
+		<loadSessionTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" name="${zap.session}" />
+	</target>
+
+	<target name="newSession">
+		<newSessionTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" name="${zap.session}" />
+	</target>
+
+	<target name="saveSession">
+		<saveSessionTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" name="${zap.session}" />
+	</target>
+
+	<target name="spider">
+		<spiderUrlTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" url="${zap.targetUrl}" />
+	</target>
+
+	<target name="stopZap">
+		<stopZapTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" />
+	</target>
+
+</project>

--- a/subprojects/zap-clientapi-ant/zap-clientapi-ant.gradle
+++ b/subprojects/zap-clientapi-ant/zap-clientapi-ant.gradle
@@ -2,6 +2,9 @@
 dependencies {
     compile project(':zap-clientapi')
     compileOnly 'org.apache.ant:ant:1.9.7'
+
+    testCompile 'org.apache.ant:ant-testutil:1.9.7'
+    testCompile 'org.nanohttpd:nanohttpd:2.3.1'
 }
 
 sourceSets { examples }


### PR DESCRIPTION
Change the Ant tasks to allow to specify the API key (move the API key
attribute to base class ZapTask) as it might be required for newer ZAP
versions.
Add tests to check that the tasks accept the expected attributes and
nested elements.