### PR TITLE
Remove printStackTrace from Ant task

### DIFF
--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
@@ -28,7 +28,6 @@ public class StopZapTask extends ZapTask {
 		try {
 			this.getClientApi().core.shutdown(null);
 		} catch (Exception e) {
-			e.printStackTrace();
 			throw new BuildException(e);
 		}
 	}


### PR DESCRIPTION
Change StopZapTask to remove the call to Throwable.printStackTrace(),
the exception is wrapped and thrown for the caller to handle (e.g. Ant
which already outputs the stack trace).