### PR TITLE
Do not require to set the API key in each call

### DIFF
--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
@@ -28,7 +28,7 @@ public class ActiveScanSubtreeTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().ascan.scan(null, url, "true", "false", "", "", "");
+			this.getClientApi().ascan.scan(url, "true", "false", "", "", "");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanUrlTask.java
@@ -28,7 +28,7 @@ public class ActiveScanUrlTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().ascan.scan(null, url, "false", "false", "", "", "");
+			this.getClientApi().ascan.scan(url, "false", "false", "", "", "");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/LoadSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/LoadSessionTask.java
@@ -28,7 +28,7 @@ public class LoadSessionTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.loadSession(null, name);
+			this.getClientApi().core.loadSession(name);
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/NewSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/NewSessionTask.java
@@ -28,7 +28,7 @@ public class NewSessionTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.newSession(null, name, "true");
+			this.getClientApi().core.newSession(name, "true");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SaveSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SaveSessionTask.java
@@ -28,7 +28,7 @@ public class SaveSessionTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.saveSession(null, name, "true");
+			this.getClientApi().core.saveSession(name, "true");
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
@@ -28,7 +28,7 @@ public class SpiderUrlTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().spider.scan(null, url, "", "", null, null);
+			this.getClientApi().spider.scan(url, "", "", null, null);
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
@@ -26,7 +26,7 @@ public class StopZapTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().core.shutdown(null);
+			this.getClientApi().core.shutdown();
 		} catch (Exception e) {
 			throw new BuildException(e);
 		}

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
@@ -43,7 +43,7 @@ public class SimpleExample {
             // Start spidering the target
             System.out.println("Spider : " + TARGET);
             // It's not necessary to pass the ZAP API key again, already set when creating the ClientApi.
-            ApiResponse resp = api.spider.scan(null, TARGET, null, null, null, null);
+            ApiResponse resp = api.spider.scan(TARGET, null, null, null, null);
             String scanid;
             int progress;
 
@@ -65,7 +65,7 @@ public class SimpleExample {
             Thread.sleep(2000);
 
             System.out.println("Active scan : " + TARGET);
-            resp = api.ascan.scan(null, TARGET, "True", "False", null, null, null);
+            resp = api.ascan.scan(TARGET, "True", "False", null, null, null);
 
             // The scan now returns a scan id to support concurrent scanning
             scanid = ((ApiResponseElement) resp).getValue();
@@ -82,7 +82,7 @@ public class SimpleExample {
             System.out.println("Active Scan complete");
 
             System.out.println("Alerts:");
-            System.out.println(new String(api.core.xmlreport(null)));
+            System.out.println(new String(api.core.xmlreport()));
 
         } catch (Exception e) {
             System.out.println("Exception : " + e.getMessage());

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
@@ -108,7 +108,7 @@ public class FormBasedAuthentication {
 		String contextId = "1";
 
 		// Actually set the logged in indicator
-		clientApi.authentication.setLoggedInIndicator(ZAP_API_KEY, contextId, java.util.regex.Pattern.quote(loggedInIndicator));
+		clientApi.authentication.setLoggedInIndicator(contextId, java.util.regex.Pattern.quote(loggedInIndicator));
 
 		// Check out the logged in indicator that is set
 		System.out.println("Configured logged in indicator regex: "
@@ -130,7 +130,7 @@ public class FormBasedAuthentication {
 
 		System.out.println("Setting form based authentication configuration as: "
 				+ formBasedConfig.toString());
-		clientApi.authentication.setAuthenticationMethod(ZAP_API_KEY, contextId, "formBasedAuthentication",
+		clientApi.authentication.setAuthenticationMethod(contextId, "formBasedAuthentication",
 				formBasedConfig.toString());
 
 		// Check if everything is set up ok
@@ -146,7 +146,7 @@ public class FormBasedAuthentication {
 		String password = "weakPassword";
 
 		// Make sure we have at least one user
-		String userId = extractUserId(clientApi.users.newUser(ZAP_API_KEY, contextId, user));
+		String userId = extractUserId(clientApi.users.newUser(contextId, user));
 
 		// Prepare the configuration in a format similar to how URL parameters are formed. This
 		// means that any value we add for the configuration values has to be URL encoded.
@@ -155,7 +155,7 @@ public class FormBasedAuthentication {
 		userAuthConfig.append("&password=").append(URLEncoder.encode(password, "UTF-8"));
 
 		System.out.println("Setting user authentication configuration as: " + userAuthConfig.toString());
-		clientApi.users.setAuthenticationCredentials(ZAP_API_KEY, contextId, userId, userAuthConfig.toString());
+		clientApi.users.setAuthenticationCredentials(contextId, userId, userAuthConfig.toString());
 
 		// Check if everything is set up ok
 		System.out.println("Authentication config: " + clientApi.users.getUserById(contextId, userId).toString(0));
@@ -172,7 +172,7 @@ public class FormBasedAuthentication {
 	 * @throws Exception if an error occurred while accessing the API
 	 */
 	public static void main(String[] args) throws Exception {
-		ClientApi clientApi = new ClientApi(ZAP_ADDRESS, ZAP_PORT);
+		ClientApi clientApi = new ClientApi(ZAP_ADDRESS, ZAP_PORT, ZAP_API_KEY);
 
 		listAuthInformation(clientApi);
 		System.out.println("-------------");

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiMain.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiMain.java
@@ -56,7 +56,7 @@ public class ClientApiMain {
         try {
             switch(task){
                 case stop:
-                    api.core.shutdown(null);
+                    api.core.shutdown();
                     break;
                 case checkAlerts:
                     if (params.get("alertsFile") == null){
@@ -99,13 +99,13 @@ public class ClientApiMain {
                         showHelp();
                         System.exit(1);
                     }
-                    api.core.saveSession(null, (String)params.get("sessionName"), "true");
+                    api.core.saveSession((String)params.get("sessionName"), "true");
                     break;
                 case newSession:
                     if (params.get("sessionName") == null){
-                        api.core.newSession(null, "", "true");
+                        api.core.newSession("", "true");
                     }else{
-                        api.core.newSession(null, (String)params.get("sessionName"), "true");
+                        api.core.newSession((String)params.get("sessionName"), "true");
                     }
                     break;
                 case activeScanUrl:
@@ -114,27 +114,27 @@ public class ClientApiMain {
                         showHelp();
                         System.exit(1);
                     }else{
-                        api.ascan.scan(null, (String)params.get("url"), "true", "false", "", "", "");
+                        api.ascan.scan((String)params.get("url"), "true", "false", "", "", "");
                     }
                     break;
                 case activeScanSiteInScope:
                     checkForUrlParam();
-                    api.activeScanSiteInScope(null, (String)params.get("url"));
+                    api.activeScanSiteInScope((String)params.get("url"));
                     break;
                 case addExcludeRegexToContext:
                     checkForContextNameParam();
                     checkForRegexParam();
-                    api.addExcludeFromContext(null, (String)params.get("contextName"), (String)params.get("regex"));
+                    api.context.excludeFromContext((String)params.get("contextName"), (String)params.get("regex"));
                     break;
                 case addIncludeRegexToContext:
                     checkForContextNameParam();
                     checkForRegexParam();
-                    api.addIncludeInContext(null, (String)params.get("contextName"), (String)params.get("regex"));
+                    api.context.includeInContext((String)params.get("contextName"), (String)params.get("regex"));
                     break;
                 case addIncludeOneMatchingNodeToContext:
                     checkForContextNameParam();
                     checkForRegexParam();
-                    api.includeOneMatchingNodeInContext(null, (String)params.get("contextName"), (String)params.get("regex"));
+                    api.includeOneMatchingNodeInContext((String)params.get("contextName"), (String)params.get("regex"));
                     break;
             }
         } catch (ConnectException e){

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Acsrf {
+@SuppressWarnings("javadoc")
+public class Acsrf extends org.zaproxy.clientapi.gen.deprecated.AcsrfDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Acsrf(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,19 +44,14 @@ public class Acsrf {
 	 * Lists the names of all anti CSRF tokens
 	 */
 	public ApiResponse optionTokensNames() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("acsrf", "view", "optionTokensNames", map);
+		return api.callApi("acsrf", "view", "optionTokensNames", null);
 	}
 
 	/**
 	 * Adds an anti CSRF token with the given name, enabled by default
 	 */
-	public ApiResponse addOptionToken(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse addOptionToken(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("acsrf", "action", "addOptionToken", map);
 	}
@@ -62,12 +59,8 @@ public class Acsrf {
 	/**
 	 * Removes the anti CSRF token with the given name
 	 */
-	public ApiResponse removeOptionToken(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeOptionToken(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("acsrf", "action", "removeOptionToken", map);
 	}
@@ -75,12 +68,8 @@ public class Acsrf {
 	/**
 	 * Generate a form for testing lack of anti CSRF tokens - typically invoked via ZAP
 	 */
-	public byte[] genForm(String apikey, String hrefid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] genForm(String hrefid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("hrefId", hrefid);
 		return api.callApiOther("acsrf", "other", "genForm", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AjaxSpider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AjaxSpider.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class AjaxSpider {
+@SuppressWarnings("javadoc")
+public class AjaxSpider extends org.zaproxy.clientapi.gen.deprecated.AjaxSpiderDeprecated {
 
 	private final ClientApi api;
 
 	public AjaxSpider(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -137,22 +139,12 @@ public class AjaxSpider {
 	}
 
 	/**
-	 * This component is optional and therefore the API will only work if it is installed.
-	 */
-	public ApiResponse scan(String apikey, String url, String inscope) throws ClientApiException {
-		return scan(apikey, url, inscope, null, null);
-	}
-	
-	/**
 	 * Runs the spider against the given URL and/or context, optionally, spidering everything in scope. The parameter 'contextName' can be used to constrain the scan to a Context, the option 'in scope' is ignored if a context was also specified. The parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse scan(String apikey, String url, String inscope, String contextname, String subtreeonly) throws ClientApiException {
+	public ApiResponse scan(String url, String inscope, String contextname, String subtreeonly) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		if (url != null) {
 			map.put("url", url);
 		}
@@ -173,11 +165,8 @@ public class AjaxSpider {
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse scanAsUser(String apikey, String contextname, String username, String url, String subtreeonly) throws ClientApiException {
+	public ApiResponse scanAsUser(String contextname, String username, String url, String subtreeonly) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("contextName", contextname);
 		map.put("userName", username);
 		if (url != null) {
@@ -192,22 +181,15 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse stop(String apikey) throws ClientApiException {
-		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("ajaxSpider", "action", "stop", map);
+	public ApiResponse stop() throws ClientApiException {
+		return api.callApi("ajaxSpider", "action", "stop", null);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionBrowserId(String apikey, String string) throws ClientApiException {
+	public ApiResponse setOptionBrowserId(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("String", string);
 		return api.callApi("ajaxSpider", "action", "setOptionBrowserId", map);
 	}
@@ -215,11 +197,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionClickDefaultElems(String apikey, boolean bool) throws ClientApiException {
+	public ApiResponse setOptionClickDefaultElems(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ajaxSpider", "action", "setOptionClickDefaultElems", map);
 	}
@@ -227,11 +206,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionClickElemsOnce(String apikey, boolean bool) throws ClientApiException {
+	public ApiResponse setOptionClickElemsOnce(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ajaxSpider", "action", "setOptionClickElemsOnce", map);
 	}
@@ -239,11 +215,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionEventWait(String apikey, int i) throws ClientApiException {
+	public ApiResponse setOptionEventWait(int i) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ajaxSpider", "action", "setOptionEventWait", map);
 	}
@@ -251,11 +224,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionMaxCrawlDepth(String apikey, int i) throws ClientApiException {
+	public ApiResponse setOptionMaxCrawlDepth(int i) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ajaxSpider", "action", "setOptionMaxCrawlDepth", map);
 	}
@@ -263,11 +233,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionMaxCrawlStates(String apikey, int i) throws ClientApiException {
+	public ApiResponse setOptionMaxCrawlStates(int i) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ajaxSpider", "action", "setOptionMaxCrawlStates", map);
 	}
@@ -275,11 +242,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionMaxDuration(String apikey, int i) throws ClientApiException {
+	public ApiResponse setOptionMaxDuration(int i) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ajaxSpider", "action", "setOptionMaxDuration", map);
 	}
@@ -287,11 +251,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionNumberOfBrowsers(String apikey, int i) throws ClientApiException {
+	public ApiResponse setOptionNumberOfBrowsers(int i) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ajaxSpider", "action", "setOptionNumberOfBrowsers", map);
 	}
@@ -299,11 +260,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionRandomInputs(String apikey, boolean bool) throws ClientApiException {
+	public ApiResponse setOptionRandomInputs(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ajaxSpider", "action", "setOptionRandomInputs", map);
 	}
@@ -311,11 +269,8 @@ public class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionReloadWait(String apikey, int i) throws ClientApiException {
+	public ApiResponse setOptionReloadWait(int i) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ajaxSpider", "action", "setOptionReloadWait", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AlertFilter.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AlertFilter.java
@@ -30,6 +30,7 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
+@SuppressWarnings("javadoc")
 public class AlertFilter {
 
 	private final ClientApi api;
@@ -52,11 +53,8 @@ public class AlertFilter {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse addAlertFilter(String apikey, String contextid, String ruleid, String newlevel, String url, String urlisregex, String parameter, String enabled) throws ClientApiException {
+	public ApiResponse addAlertFilter(String contextid, String ruleid, String newlevel, String url, String urlisregex, String parameter, String enabled) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("contextId", contextid);
 		map.put("ruleId", ruleid);
 		map.put("newLevel", newlevel);
@@ -78,11 +76,8 @@ public class AlertFilter {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse removeAlertFilter(String apikey, String contextid, String ruleid, String newlevel, String url, String urlisregex, String parameter, String enabled) throws ClientApiException {
+	public ApiResponse removeAlertFilter(String contextid, String ruleid, String newlevel, String url, String urlisregex, String parameter, String enabled) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("contextId", contextid);
 		map.put("ruleId", ruleid);
 		map.put("newLevel", newlevel);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
@@ -30,17 +30,18 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Ascan {
+@SuppressWarnings("javadoc")
+public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Ascan(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	public ApiResponse status(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (scanid != null) {
 			map.put("scanId", scanid);
 		}
@@ -48,8 +49,7 @@ public class Ascan {
 	}
 
 	public ApiResponse scanProgress(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (scanid != null) {
 			map.put("scanId", scanid);
 		}
@@ -57,37 +57,31 @@ public class Ascan {
 	}
 
 	public ApiResponse messagesIds(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "view", "messagesIds", map);
 	}
 
 	public ApiResponse alertsIds(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "view", "alertsIds", map);
 	}
 
 	public ApiResponse scans() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "scans", map);
+		return api.callApi("ascan", "view", "scans", null);
 	}
 
 	public ApiResponse scanPolicyNames() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "scanPolicyNames", map);
+		return api.callApi("ascan", "view", "scanPolicyNames", null);
 	}
 
 	public ApiResponse excludedFromScan() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "excludedFromScan", map);
+		return api.callApi("ascan", "view", "excludedFromScan", null);
 	}
 
 	public ApiResponse scanners(String scanpolicyname, String policyid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
 		}
@@ -98,8 +92,7 @@ public class Ascan {
 	}
 
 	public ApiResponse policies(String scanpolicyname, String policyid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
 		}
@@ -110,114 +103,90 @@ public class Ascan {
 	}
 
 	public ApiResponse attackModeQueue() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "attackModeQueue", map);
+		return api.callApi("ascan", "view", "attackModeQueue", null);
 	}
 
 	public ApiResponse optionAttackPolicy() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionAttackPolicy", map);
+		return api.callApi("ascan", "view", "optionAttackPolicy", null);
 	}
 
 	public ApiResponse optionDefaultPolicy() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionDefaultPolicy", map);
+		return api.callApi("ascan", "view", "optionDefaultPolicy", null);
 	}
 
 	public ApiResponse optionDelayInMs() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionDelayInMs", map);
+		return api.callApi("ascan", "view", "optionDelayInMs", null);
 	}
 
 	public ApiResponse optionExcludedParamList() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionExcludedParamList", map);
+		return api.callApi("ascan", "view", "optionExcludedParamList", null);
 	}
 
 	public ApiResponse optionHandleAntiCSRFTokens() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionHandleAntiCSRFTokens", map);
+		return api.callApi("ascan", "view", "optionHandleAntiCSRFTokens", null);
 	}
 
 	public ApiResponse optionHostPerScan() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionHostPerScan", map);
+		return api.callApi("ascan", "view", "optionHostPerScan", null);
 	}
 
 	public ApiResponse optionMaxChartTimeInMins() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionMaxChartTimeInMins", map);
+		return api.callApi("ascan", "view", "optionMaxChartTimeInMins", null);
 	}
 
 	public ApiResponse optionMaxResultsToList() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionMaxResultsToList", map);
+		return api.callApi("ascan", "view", "optionMaxResultsToList", null);
 	}
 
 	public ApiResponse optionMaxScansInUI() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionMaxScansInUI", map);
+		return api.callApi("ascan", "view", "optionMaxScansInUI", null);
 	}
 
 	public ApiResponse optionTargetParamsEnabledRPC() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionTargetParamsEnabledRPC", map);
+		return api.callApi("ascan", "view", "optionTargetParamsEnabledRPC", null);
 	}
 
 	public ApiResponse optionTargetParamsInjectable() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionTargetParamsInjectable", map);
+		return api.callApi("ascan", "view", "optionTargetParamsInjectable", null);
 	}
 
 	public ApiResponse optionThreadPerHost() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionThreadPerHost", map);
+		return api.callApi("ascan", "view", "optionThreadPerHost", null);
 	}
 
 	public ApiResponse optionAllowAttackOnStart() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionAllowAttackOnStart", map);
+		return api.callApi("ascan", "view", "optionAllowAttackOnStart", null);
 	}
 
 	public ApiResponse optionInjectPluginIdInHeader() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionInjectPluginIdInHeader", map);
+		return api.callApi("ascan", "view", "optionInjectPluginIdInHeader", null);
 	}
 
 	public ApiResponse optionPromptInAttackMode() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionPromptInAttackMode", map);
+		return api.callApi("ascan", "view", "optionPromptInAttackMode", null);
 	}
 
 	public ApiResponse optionPromptToClearFinishedScans() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionPromptToClearFinishedScans", map);
+		return api.callApi("ascan", "view", "optionPromptToClearFinishedScans", null);
 	}
 
 	public ApiResponse optionRescanInAttackMode() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionRescanInAttackMode", map);
+		return api.callApi("ascan", "view", "optionRescanInAttackMode", null);
 	}
 
 	/**
 	 * Tells whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
 	 */
 	public ApiResponse optionScanHeadersAllRequests() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionScanHeadersAllRequests", map);
+		return api.callApi("ascan", "view", "optionScanHeadersAllRequests", null);
 	}
 
 	public ApiResponse optionShowAdvancedDialog() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("ascan", "view", "optionShowAdvancedDialog", map);
+		return api.callApi("ascan", "view", "optionShowAdvancedDialog", null);
 	}
 
-	public ApiResponse scan(String apikey, String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse scan(String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("url", url);
 		if (recurse != null) {
 			map.put("recurse", recurse);
@@ -240,12 +209,8 @@ public class Ascan {
 	/**
 	 * Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 	 */
-	public ApiResponse scanAsUser(String apikey, String url, String contextid, String userid, String recurse, String scanpolicyname, String method, String postdata) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse scanAsUser(String url, String contextid, String userid, String recurse, String scanpolicyname, String method, String postdata) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("url", url);
 		map.put("contextId", contextid);
 		map.put("userId", userid);
@@ -264,131 +229,74 @@ public class Ascan {
 		return api.callApi("ascan", "action", "scanAsUser", map);
 	}
 
-	public ApiResponse pause(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse pause(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "action", "pause", map);
 	}
 
-	public ApiResponse resume(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse resume(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "action", "resume", map);
 	}
 
-	public ApiResponse stop(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse stop(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "action", "stop", map);
 	}
 
-	public ApiResponse removeScan(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeScan(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "action", "removeScan", map);
 	}
 
-	public ApiResponse pauseAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("ascan", "action", "pauseAllScans", map);
+	public ApiResponse pauseAllScans() throws ClientApiException {
+		return api.callApi("ascan", "action", "pauseAllScans", null);
 	}
 
-	public ApiResponse resumeAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("ascan", "action", "resumeAllScans", map);
+	public ApiResponse resumeAllScans() throws ClientApiException {
+		return api.callApi("ascan", "action", "resumeAllScans", null);
 	}
 
-	public ApiResponse stopAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("ascan", "action", "stopAllScans", map);
+	public ApiResponse stopAllScans() throws ClientApiException {
+		return api.callApi("ascan", "action", "stopAllScans", null);
 	}
 
-	public ApiResponse removeAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("ascan", "action", "removeAllScans", map);
+	public ApiResponse removeAllScans() throws ClientApiException {
+		return api.callApi("ascan", "action", "removeAllScans", null);
 	}
 
-	public ApiResponse clearExcludedFromScan(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("ascan", "action", "clearExcludedFromScan", map);
+	public ApiResponse clearExcludedFromScan() throws ClientApiException {
+		return api.callApi("ascan", "action", "clearExcludedFromScan", null);
 	}
 
-	public ApiResponse excludeFromScan(String apikey, String regex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse excludeFromScan(String regex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		return api.callApi("ascan", "action", "excludeFromScan", map);
 	}
 
-	public ApiResponse enableAllScanners(String apikey, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse enableAllScanners(String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
 		}
 		return api.callApi("ascan", "action", "enableAllScanners", map);
 	}
 
-	public ApiResponse disableAllScanners(String apikey, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse disableAllScanners(String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
 		}
 		return api.callApi("ascan", "action", "disableAllScanners", map);
 	}
 
-	public ApiResponse enableScanners(String apikey, String ids, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse enableScanners(String ids, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("ids", ids);
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
@@ -396,12 +304,8 @@ public class Ascan {
 		return api.callApi("ascan", "action", "enableScanners", map);
 	}
 
-	public ApiResponse disableScanners(String apikey, String ids, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse disableScanners(String ids, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("ids", ids);
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
@@ -409,12 +313,8 @@ public class Ascan {
 		return api.callApi("ascan", "action", "disableScanners", map);
 	}
 
-	public ApiResponse setEnabledPolicies(String apikey, String ids, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setEnabledPolicies(String ids, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("ids", ids);
 		if (scanpolicyname != null) {
 			map.put("scanPolicyName", scanpolicyname);
@@ -422,12 +322,8 @@ public class Ascan {
 		return api.callApi("ascan", "action", "setEnabledPolicies", map);
 	}
 
-	public ApiResponse setPolicyAttackStrength(String apikey, String id, String attackstrength, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setPolicyAttackStrength(String id, String attackstrength, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		map.put("attackStrength", attackstrength);
 		if (scanpolicyname != null) {
@@ -436,12 +332,8 @@ public class Ascan {
 		return api.callApi("ascan", "action", "setPolicyAttackStrength", map);
 	}
 
-	public ApiResponse setPolicyAlertThreshold(String apikey, String id, String alertthreshold, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setPolicyAlertThreshold(String id, String alertthreshold, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		map.put("alertThreshold", alertthreshold);
 		if (scanpolicyname != null) {
@@ -450,12 +342,8 @@ public class Ascan {
 		return api.callApi("ascan", "action", "setPolicyAlertThreshold", map);
 	}
 
-	public ApiResponse setScannerAttackStrength(String apikey, String id, String attackstrength, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setScannerAttackStrength(String id, String attackstrength, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		map.put("attackStrength", attackstrength);
 		if (scanpolicyname != null) {
@@ -464,12 +352,8 @@ public class Ascan {
 		return api.callApi("ascan", "action", "setScannerAttackStrength", map);
 	}
 
-	public ApiResponse setScannerAlertThreshold(String apikey, String id, String alertthreshold, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setScannerAlertThreshold(String id, String alertthreshold, String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		map.put("alertThreshold", alertthreshold);
 		if (scanpolicyname != null) {
@@ -478,152 +362,92 @@ public class Ascan {
 		return api.callApi("ascan", "action", "setScannerAlertThreshold", map);
 	}
 
-	public ApiResponse addScanPolicy(String apikey, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse addScanPolicy(String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanPolicyName", scanpolicyname);
 		return api.callApi("ascan", "action", "addScanPolicy", map);
 	}
 
-	public ApiResponse removeScanPolicy(String apikey, String scanpolicyname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeScanPolicy(String scanpolicyname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanPolicyName", scanpolicyname);
 		return api.callApi("ascan", "action", "removeScanPolicy", map);
 	}
 
-	public ApiResponse setOptionAttackPolicy(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionAttackPolicy(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("ascan", "action", "setOptionAttackPolicy", map);
 	}
 
-	public ApiResponse setOptionDefaultPolicy(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionDefaultPolicy(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("ascan", "action", "setOptionDefaultPolicy", map);
 	}
 
-	public ApiResponse setOptionAllowAttackOnStart(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionAllowAttackOnStart(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionAllowAttackOnStart", map);
 	}
 
-	public ApiResponse setOptionDelayInMs(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionDelayInMs(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionDelayInMs", map);
 	}
 
-	public ApiResponse setOptionHandleAntiCSRFTokens(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionHandleAntiCSRFTokens(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionHandleAntiCSRFTokens", map);
 	}
 
-	public ApiResponse setOptionHostPerScan(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionHostPerScan(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionHostPerScan", map);
 	}
 
-	public ApiResponse setOptionInjectPluginIdInHeader(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionInjectPluginIdInHeader(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionInjectPluginIdInHeader", map);
 	}
 
-	public ApiResponse setOptionMaxChartTimeInMins(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionMaxChartTimeInMins(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionMaxChartTimeInMins", map);
 	}
 
-	public ApiResponse setOptionMaxResultsToList(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionMaxResultsToList(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionMaxResultsToList", map);
 	}
 
-	public ApiResponse setOptionMaxScansInUI(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionMaxScansInUI(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionMaxScansInUI", map);
 	}
 
-	public ApiResponse setOptionPromptInAttackMode(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionPromptInAttackMode(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionPromptInAttackMode", map);
 	}
 
-	public ApiResponse setOptionPromptToClearFinishedScans(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionPromptToClearFinishedScans(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionPromptToClearFinishedScans", map);
 	}
 
-	public ApiResponse setOptionRescanInAttackMode(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionRescanInAttackMode(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionRescanInAttackMode", map);
 	}
@@ -631,52 +455,32 @@ public class Ascan {
 	/**
 	 * Sets whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
 	 */
-	public ApiResponse setOptionScanHeadersAllRequests(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionScanHeadersAllRequests(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionScanHeadersAllRequests", map);
 	}
 
-	public ApiResponse setOptionShowAdvancedDialog(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionShowAdvancedDialog(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("ascan", "action", "setOptionShowAdvancedDialog", map);
 	}
 
-	public ApiResponse setOptionTargetParamsEnabledRPC(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionTargetParamsEnabledRPC(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionTargetParamsEnabledRPC", map);
 	}
 
-	public ApiResponse setOptionTargetParamsInjectable(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionTargetParamsInjectable(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionTargetParamsInjectable", map);
 	}
 
-	public ApiResponse setOptionThreadPerHost(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionThreadPerHost(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionThreadPerHost", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authentication.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authentication.java
@@ -30,53 +30,46 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Authentication {
+@SuppressWarnings("javadoc")
+public class Authentication extends org.zaproxy.clientapi.gen.deprecated.AuthenticationDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Authentication(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	public ApiResponse getSupportedAuthenticationMethods() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("authentication", "view", "getSupportedAuthenticationMethods", map);
+		return api.callApi("authentication", "view", "getSupportedAuthenticationMethods", null);
 	}
 
 	public ApiResponse getAuthenticationMethodConfigParams(String authmethodname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("authMethodName", authmethodname);
 		return api.callApi("authentication", "view", "getAuthenticationMethodConfigParams", map);
 	}
 
 	public ApiResponse getAuthenticationMethod(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("authentication", "view", "getAuthenticationMethod", map);
 	}
 
 	public ApiResponse getLoggedInIndicator(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("authentication", "view", "getLoggedInIndicator", map);
 	}
 
 	public ApiResponse getLoggedOutIndicator(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("authentication", "view", "getLoggedOutIndicator", map);
 	}
 
-	public ApiResponse setAuthenticationMethod(String apikey, String contextid, String authmethodname, String authmethodconfigparams) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setAuthenticationMethod(String contextid, String authmethodname, String authmethodconfigparams) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("authMethodName", authmethodname);
 		if (authmethodconfigparams != null) {
@@ -85,23 +78,15 @@ public class Authentication {
 		return api.callApi("authentication", "action", "setAuthenticationMethod", map);
 	}
 
-	public ApiResponse setLoggedInIndicator(String apikey, String contextid, String loggedinindicatorregex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setLoggedInIndicator(String contextid, String loggedinindicatorregex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("loggedInIndicatorRegex", loggedinindicatorregex);
 		return api.callApi("authentication", "action", "setLoggedInIndicator", map);
 	}
 
-	public ApiResponse setLoggedOutIndicator(String apikey, String contextid, String loggedoutindicatorregex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setLoggedOutIndicator(String contextid, String loggedoutindicatorregex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("loggedOutIndicatorRegex", loggedoutindicatorregex);
 		return api.callApi("authentication", "action", "setLoggedOutIndicator", map);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authorization.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authorization.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Authorization {
+@SuppressWarnings("javadoc")
+public class Authorization extends org.zaproxy.clientapi.gen.deprecated.AuthorizationDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Authorization(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,8 +44,7 @@ public class Authorization {
 	 * Obtains all the configuration of the authorization detection method that is currently set for a context.
 	 */
 	public ApiResponse getAuthorizationDetectionMethod(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("authorization", "view", "getAuthorizationDetectionMethod", map);
 	}
@@ -51,12 +52,8 @@ public class Authorization {
 	/**
 	 * Sets the authorization detection method for a context as one that identifies un-authorized messages based on: the message's status code or a regex pattern in the response's header or body. Also, whether all conditions must match or just some can be specified via the logicalOperator parameter, which accepts two values: "AND" (default), "OR".  
 	 */
-	public ApiResponse setBasicAuthorizationDetectionMethod(String apikey, String contextid, String headerregex, String bodyregex, String statuscode, String logicaloperator) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setBasicAuthorizationDetectionMethod(String contextid, String headerregex, String bodyregex, String statuscode, String logicaloperator) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		if (headerregex != null) {
 			map.put("headerRegex", headerregex);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Autoupdate {
+@SuppressWarnings("javadoc")
+public class Autoupdate extends org.zaproxy.clientapi.gen.deprecated.AutoupdateDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Autoupdate(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,171 +44,119 @@ public class Autoupdate {
 	 * Returns the latest version number
 	 */
 	public ApiResponse latestVersionNumber() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "latestVersionNumber", map);
+		return api.callApi("autoupdate", "view", "latestVersionNumber", null);
 	}
 
 	/**
 	 * Returns 'true' if ZAP is on the latest version
 	 */
 	public ApiResponse isLatestVersion() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "isLatestVersion", map);
+		return api.callApi("autoupdate", "view", "isLatestVersion", null);
 	}
 
 	public ApiResponse optionAddonDirectories() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionAddonDirectories", map);
+		return api.callApi("autoupdate", "view", "optionAddonDirectories", null);
 	}
 
 	public ApiResponse optionDayLastChecked() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionDayLastChecked", map);
+		return api.callApi("autoupdate", "view", "optionDayLastChecked", null);
 	}
 
 	public ApiResponse optionDayLastInstallWarned() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionDayLastInstallWarned", map);
+		return api.callApi("autoupdate", "view", "optionDayLastInstallWarned", null);
 	}
 
 	public ApiResponse optionDayLastUpdateWarned() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionDayLastUpdateWarned", map);
+		return api.callApi("autoupdate", "view", "optionDayLastUpdateWarned", null);
 	}
 
 	public ApiResponse optionDownloadDirectory() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionDownloadDirectory", map);
+		return api.callApi("autoupdate", "view", "optionDownloadDirectory", null);
 	}
 
 	public ApiResponse optionCheckAddonUpdates() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionCheckAddonUpdates", map);
+		return api.callApi("autoupdate", "view", "optionCheckAddonUpdates", null);
 	}
 
 	public ApiResponse optionCheckOnStart() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionCheckOnStart", map);
+		return api.callApi("autoupdate", "view", "optionCheckOnStart", null);
 	}
 
 	public ApiResponse optionDownloadNewRelease() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionDownloadNewRelease", map);
+		return api.callApi("autoupdate", "view", "optionDownloadNewRelease", null);
 	}
 
 	public ApiResponse optionInstallAddonUpdates() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionInstallAddonUpdates", map);
+		return api.callApi("autoupdate", "view", "optionInstallAddonUpdates", null);
 	}
 
 	public ApiResponse optionInstallScannerRules() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionInstallScannerRules", map);
+		return api.callApi("autoupdate", "view", "optionInstallScannerRules", null);
 	}
 
 	public ApiResponse optionReportAlphaAddons() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionReportAlphaAddons", map);
+		return api.callApi("autoupdate", "view", "optionReportAlphaAddons", null);
 	}
 
 	public ApiResponse optionReportBetaAddons() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionReportBetaAddons", map);
+		return api.callApi("autoupdate", "view", "optionReportBetaAddons", null);
 	}
 
 	public ApiResponse optionReportReleaseAddons() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("autoupdate", "view", "optionReportReleaseAddons", map);
+		return api.callApi("autoupdate", "view", "optionReportReleaseAddons", null);
 	}
 
 	/**
 	 * Downloads the latest release, if any 
 	 */
-	public ApiResponse downloadLatestRelease(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("autoupdate", "action", "downloadLatestRelease", map);
+	public ApiResponse downloadLatestRelease() throws ClientApiException {
+		return api.callApi("autoupdate", "action", "downloadLatestRelease", null);
 	}
 
-	public ApiResponse setOptionCheckAddonUpdates(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionCheckAddonUpdates(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionCheckAddonUpdates", map);
 	}
 
-	public ApiResponse setOptionCheckOnStart(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionCheckOnStart(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionCheckOnStart", map);
 	}
 
-	public ApiResponse setOptionDownloadNewRelease(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionDownloadNewRelease(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionDownloadNewRelease", map);
 	}
 
-	public ApiResponse setOptionInstallAddonUpdates(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionInstallAddonUpdates(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionInstallAddonUpdates", map);
 	}
 
-	public ApiResponse setOptionInstallScannerRules(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionInstallScannerRules(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionInstallScannerRules", map);
 	}
 
-	public ApiResponse setOptionReportAlphaAddons(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionReportAlphaAddons(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionReportAlphaAddons", map);
 	}
 
-	public ApiResponse setOptionReportBetaAddons(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionReportBetaAddons(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionReportBetaAddons", map);
 	}
 
-	public ApiResponse setOptionReportReleaseAddons(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionReportReleaseAddons(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("autoupdate", "action", "setOptionReportReleaseAddons", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
@@ -30,32 +30,26 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Break {
+@SuppressWarnings("javadoc")
+public class Break extends org.zaproxy.clientapi.gen.deprecated.BreakDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Break(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
-	public ApiResponse brk(String apikey, String type, String scope, String state) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse brk(String type, String scope, String state) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("type", type);
 		map.put("scope", scope);
 		map.put("state", state);
 		return api.callApi("break", "action", "break", map);
 	}
 
-	public ApiResponse addHttpBreakpoint(String apikey, String string, String location, String match, String inverse, String ignorecase) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse addHttpBreakpoint(String string, String location, String match, String inverse, String ignorecase) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("string", string);
 		map.put("location", location);
 		map.put("match", match);
@@ -64,12 +58,8 @@ public class Break {
 		return api.callApi("break", "action", "addHttpBreakpoint", map);
 	}
 
-	public ApiResponse removeHttpBreakpoint(String apikey, String string, String location, String match, String inverse, String ignorecase) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeHttpBreakpoint(String string, String location, String match, String inverse, String ignorecase) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("string", string);
 		map.put("location", location);
 		map.put("match", match);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Context.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Context.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Context {
+@SuppressWarnings("javadoc")
+public class Context extends org.zaproxy.clientapi.gen.deprecated.ContextDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Context(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,16 +44,14 @@ public class Context {
 	 * List context names of current session
 	 */
 	public ApiResponse contextList() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("context", "view", "contextList", map);
+		return api.callApi("context", "view", "contextList", null);
 	}
 
 	/**
 	 * List excluded regexs for context
 	 */
 	public ApiResponse excludeRegexs(String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "view", "excludeRegexs", map);
 	}
@@ -60,8 +60,7 @@ public class Context {
 	 * List included regexs for context
 	 */
 	public ApiResponse includeRegexs(String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "view", "includeRegexs", map);
 	}
@@ -70,8 +69,7 @@ public class Context {
 	 * List the information about the named context
 	 */
 	public ApiResponse context(String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "view", "context", map);
 	}
@@ -80,16 +78,14 @@ public class Context {
 	 * Lists the names of all built in technologies
 	 */
 	public ApiResponse technologyList() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("context", "view", "technologyList", map);
+		return api.callApi("context", "view", "technologyList", null);
 	}
 
 	/**
 	 * Lists the names of all technologies included in a context
 	 */
 	public ApiResponse includedTechnologyList(String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "view", "includedTechnologyList", map);
 	}
@@ -98,8 +94,7 @@ public class Context {
 	 * Lists the names of all technologies excluded from a context
 	 */
 	public ApiResponse excludedTechnologyList(String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "view", "excludedTechnologyList", map);
 	}
@@ -107,12 +102,8 @@ public class Context {
 	/**
 	 * Add exclude regex to context
 	 */
-	public ApiResponse excludeFromContext(String apikey, String contextname, String regex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse excludeFromContext(String contextname, String regex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		map.put("regex", regex);
 		return api.callApi("context", "action", "excludeFromContext", map);
@@ -121,12 +112,8 @@ public class Context {
 	/**
 	 * Add include regex to context
 	 */
-	public ApiResponse includeInContext(String apikey, String contextname, String regex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse includeInContext(String contextname, String regex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		map.put("regex", regex);
 		return api.callApi("context", "action", "includeInContext", map);
@@ -135,12 +122,8 @@ public class Context {
 	/**
 	 * Creates a new context with the given name in the current session
 	 */
-	public ApiResponse newContext(String apikey, String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse newContext(String contextname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "action", "newContext", map);
 	}
@@ -148,12 +131,8 @@ public class Context {
 	/**
 	 * Removes a context in the current session
 	 */
-	public ApiResponse removeContext(String apikey, String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeContext(String contextname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "action", "removeContext", map);
 	}
@@ -161,12 +140,8 @@ public class Context {
 	/**
 	 * Exports the context with the given name to a file. If a relative file path is specified it will be resolved against the "contexts" directory in ZAP "home" dir.
 	 */
-	public ApiResponse exportContext(String apikey, String contextname, String contextfile) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse exportContext(String contextname, String contextfile) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		map.put("contextFile", contextfile);
 		return api.callApi("context", "action", "exportContext", map);
@@ -175,12 +150,8 @@ public class Context {
 	/**
 	 * Imports a context from a file. If a relative file path is specified it will be resolved against the "contexts" directory in ZAP "home" dir.
 	 */
-	public ApiResponse importContext(String apikey, String contextfile) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse importContext(String contextfile) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextFile", contextfile);
 		return api.callApi("context", "action", "importContext", map);
 	}
@@ -188,12 +159,8 @@ public class Context {
 	/**
 	 * Includes technologies with the given names, separated by a comma, to a context
 	 */
-	public ApiResponse includeContextTechnologies(String apikey, String contextname, String technologynames) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse includeContextTechnologies(String contextname, String technologynames) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		map.put("technologyNames", technologynames);
 		return api.callApi("context", "action", "includeContextTechnologies", map);
@@ -202,12 +169,8 @@ public class Context {
 	/**
 	 * Includes all built in technologies in to a context
 	 */
-	public ApiResponse includeAllContextTechnologies(String apikey, String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse includeAllContextTechnologies(String contextname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "action", "includeAllContextTechnologies", map);
 	}
@@ -215,12 +178,8 @@ public class Context {
 	/**
 	 * Excludes technologies with the given names, separated by a comma, from a context
 	 */
-	public ApiResponse excludeContextTechnologies(String apikey, String contextname, String technologynames) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse excludeContextTechnologies(String contextname, String technologynames) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		map.put("technologyNames", technologynames);
 		return api.callApi("context", "action", "excludeContextTechnologies", map);
@@ -229,12 +188,8 @@ public class Context {
 	/**
 	 * Excludes all built in technologies from a context
 	 */
-	public ApiResponse excludeAllContextTechnologies(String apikey, String contextname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse excludeAllContextTechnologies(String contextname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		return api.callApi("context", "action", "excludeAllContextTechnologies", map);
 	}
@@ -242,12 +197,8 @@ public class Context {
 	/**
 	 * Sets a context to in scope (contexts are in scope by default)
 	 */
-	public ApiResponse setContextInScope(String apikey, String contextname, String booleaninscope) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setContextInScope(String contextname, String booleaninscope) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextName", contextname);
 		map.put("booleanInScope", booleaninscope);
 		return api.callApi("context", "action", "setContextInScope", map);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Core {
+@SuppressWarnings("javadoc")
+public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Core(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,8 +44,7 @@ public class Core {
 	 * Gets the alert with the given ID, the corresponding HTTP message can be obtained with the 'messageId' field and 'message' API method
 	 */
 	public ApiResponse alert(String id) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		return api.callApi("core", "view", "alert", map);
 	}
@@ -52,8 +53,7 @@ public class Core {
 	 * Gets the alerts raised by ZAP, optionally filtering by URL and paginating with 'start' position and 'count' of alerts
 	 */
 	public ApiResponse alerts(String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
 		}
@@ -70,8 +70,7 @@ public class Core {
 	 * Gets the number of alerts, optionally filtering by URL
 	 */
 	public ApiResponse numberOfAlerts(String baseurl) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
 		}
@@ -82,32 +81,28 @@ public class Core {
 	 * Gets the name of the hosts accessed through/by ZAP
 	 */
 	public ApiResponse hosts() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "hosts", map);
+		return api.callApi("core", "view", "hosts", null);
 	}
 
 	/**
 	 * Gets the sites accessed through/by ZAP (scheme and domain)
 	 */
 	public ApiResponse sites() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "sites", map);
+		return api.callApi("core", "view", "sites", null);
 	}
 
 	/**
 	 * Gets the URLs accessed through/by ZAP
 	 */
 	public ApiResponse urls() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "urls", map);
+		return api.callApi("core", "view", "urls", null);
 	}
 
 	/**
 	 * Gets the HTTP message with the given ID. Returns the ID, request/response headers and bodies, cookies and note.
 	 */
 	public ApiResponse message(String id) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		return api.callApi("core", "view", "message", map);
 	}
@@ -116,8 +111,7 @@ public class Core {
 	 * Gets the HTTP messages sent by ZAP, request and response, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 	 */
 	public ApiResponse messages(String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
 		}
@@ -134,8 +128,7 @@ public class Core {
 	 * Gets the number of messages, optionally filtering by URL
 	 */
 	public ApiResponse numberOfMessages(String baseurl) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
 		}
@@ -146,120 +139,96 @@ public class Core {
 	 * Gets the mode
 	 */
 	public ApiResponse mode() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "mode", map);
+		return api.callApi("core", "view", "mode", null);
 	}
 
 	/**
 	 * Gets ZAP version
 	 */
 	public ApiResponse version() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "version", map);
+		return api.callApi("core", "view", "version", null);
 	}
 
 	/**
 	 * Gets the regular expressions, applied to URLs, to exclude from the Proxy
 	 */
 	public ApiResponse excludedFromProxy() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "excludedFromProxy", map);
+		return api.callApi("core", "view", "excludedFromProxy", null);
 	}
 
 	public ApiResponse homeDirectory() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "homeDirectory", map);
+		return api.callApi("core", "view", "homeDirectory", null);
 	}
 
 	public ApiResponse optionDefaultUserAgent() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionDefaultUserAgent", map);
+		return api.callApi("core", "view", "optionDefaultUserAgent", null);
 	}
 
 	public ApiResponse optionHttpState() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionHttpState", map);
+		return api.callApi("core", "view", "optionHttpState", null);
 	}
 
 	public ApiResponse optionProxyChainName() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainName", map);
+		return api.callApi("core", "view", "optionProxyChainName", null);
 	}
 
 	public ApiResponse optionProxyChainPassword() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainPassword", map);
+		return api.callApi("core", "view", "optionProxyChainPassword", null);
 	}
 
 	public ApiResponse optionProxyChainPort() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainPort", map);
+		return api.callApi("core", "view", "optionProxyChainPort", null);
 	}
 
 	public ApiResponse optionProxyChainRealm() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainRealm", map);
+		return api.callApi("core", "view", "optionProxyChainRealm", null);
 	}
 
 	public ApiResponse optionProxyChainSkipName() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainSkipName", map);
+		return api.callApi("core", "view", "optionProxyChainSkipName", null);
 	}
 
 	public ApiResponse optionProxyChainUserName() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainUserName", map);
+		return api.callApi("core", "view", "optionProxyChainUserName", null);
 	}
 
 	public ApiResponse optionProxyExcludedDomains() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyExcludedDomains", map);
+		return api.callApi("core", "view", "optionProxyExcludedDomains", null);
 	}
 
 	public ApiResponse optionProxyExcludedDomainsEnabled() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyExcludedDomainsEnabled", map);
+		return api.callApi("core", "view", "optionProxyExcludedDomainsEnabled", null);
 	}
 
 	public ApiResponse optionTimeoutInSecs() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionTimeoutInSecs", map);
+		return api.callApi("core", "view", "optionTimeoutInSecs", null);
 	}
 
 	public ApiResponse optionHttpStateEnabled() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionHttpStateEnabled", map);
+		return api.callApi("core", "view", "optionHttpStateEnabled", null);
 	}
 
 	public ApiResponse optionProxyChainPrompt() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionProxyChainPrompt", map);
+		return api.callApi("core", "view", "optionProxyChainPrompt", null);
 	}
 
 	public ApiResponse optionSingleCookieRequestHeader() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionSingleCookieRequestHeader", map);
+		return api.callApi("core", "view", "optionSingleCookieRequestHeader", null);
 	}
 
 	public ApiResponse optionUseProxyChain() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionUseProxyChain", map);
+		return api.callApi("core", "view", "optionUseProxyChain", null);
 	}
 
 	public ApiResponse optionUseProxyChainAuth() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("core", "view", "optionUseProxyChainAuth", map);
+		return api.callApi("core", "view", "optionUseProxyChainAuth", null);
 	}
 
 	/**
 	 * Convenient and simple action to access a URL, optionally following redirections. Returns the request sent and response received and followed redirections, if any. Other actions are available which offer more control on what is sent, like, 'sendRequest' or 'sendHarRequest'.
 	 */
-	public ApiResponse accessUrl(String apikey, String url, String followredirects) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse accessUrl(String url, String followredirects) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("url", url);
 		if (followredirects != null) {
 			map.put("followRedirects", followredirects);
@@ -270,24 +239,15 @@ public class Core {
 	/**
 	 * Shuts down ZAP
 	 */
-	public ApiResponse shutdown(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("core", "action", "shutdown", map);
+	public ApiResponse shutdown() throws ClientApiException {
+		return api.callApi("core", "action", "shutdown", null);
 	}
 
 	/**
 	 * Creates a new session, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 	 */
-	public ApiResponse newSession(String apikey, String name, String overwrite) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse newSession(String name, String overwrite) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (name != null) {
 			map.put("name", name);
 		}
@@ -300,12 +260,8 @@ public class Core {
 	/**
 	 * Loads the session with the given name. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 	 */
-	public ApiResponse loadSession(String apikey, String name) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse loadSession(String name) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("name", name);
 		return api.callApi("core", "action", "loadSession", map);
 	}
@@ -313,12 +269,8 @@ public class Core {
 	/**
 	 * Saves the session with the name supplied, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 	 */
-	public ApiResponse saveSession(String apikey, String name, String overwrite) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse saveSession(String name, String overwrite) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("name", name);
 		if (overwrite != null) {
 			map.put("overwrite", overwrite);
@@ -326,40 +278,22 @@ public class Core {
 		return api.callApi("core", "action", "saveSession", map);
 	}
 
-	public ApiResponse snapshotSession(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("core", "action", "snapshotSession", map);
+	public ApiResponse snapshotSession() throws ClientApiException {
+		return api.callApi("core", "action", "snapshotSession", null);
 	}
 
-	public ApiResponse clearExcludedFromProxy(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("core", "action", "clearExcludedFromProxy", map);
+	public ApiResponse clearExcludedFromProxy() throws ClientApiException {
+		return api.callApi("core", "action", "clearExcludedFromProxy", null);
 	}
 
-	public ApiResponse excludeFromProxy(String apikey, String regex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse excludeFromProxy(String regex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		return api.callApi("core", "action", "excludeFromProxy", map);
 	}
 
-	public ApiResponse setHomeDirectory(String apikey, String dir) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setHomeDirectory(String dir) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("dir", dir);
 		return api.callApi("core", "action", "setHomeDirectory", map);
 	}
@@ -367,34 +301,21 @@ public class Core {
 	/**
 	 * Sets the mode, which may be one of [safe, protect, standard, attack]
 	 */
-	public ApiResponse setMode(String apikey, String mode) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setMode(String mode) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("mode", mode);
 		return api.callApi("core", "action", "setMode", map);
 	}
 
-	public ApiResponse generateRootCA(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("core", "action", "generateRootCA", map);
+	public ApiResponse generateRootCA() throws ClientApiException {
+		return api.callApi("core", "action", "generateRootCA", null);
 	}
 
 	/**
 	 * Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any.
 	 */
-	public ApiResponse sendRequest(String apikey, String request, String followredirects) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse sendRequest(String request, String followredirects) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("request", request);
 		if (followredirects != null) {
 			map.put("followRedirects", followredirects);
@@ -402,33 +323,19 @@ public class Core {
 		return api.callApi("core", "action", "sendRequest", map);
 	}
 
-	public ApiResponse deleteAllAlerts(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("core", "action", "deleteAllAlerts", map);
+	public ApiResponse deleteAllAlerts() throws ClientApiException {
+		return api.callApi("core", "action", "deleteAllAlerts", null);
 	}
 
-	public ApiResponse runGarbageCollection(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("core", "action", "runGarbageCollection", map);
+	public ApiResponse runGarbageCollection() throws ClientApiException {
+		return api.callApi("core", "action", "runGarbageCollection", null);
 	}
 
 	/**
 	 * Deletes the site node found in the Sites Tree on the basis of the URL, HTTP method, and post data (if applicable and specified). 
 	 */
-	public ApiResponse deleteSiteNode(String apikey, String url, String method, String postdata) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse deleteSiteNode(String url, String method, String postdata) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("url", url);
 		if (method != null) {
 			map.put("method", method);
@@ -439,160 +346,94 @@ public class Core {
 		return api.callApi("core", "action", "deleteSiteNode", map);
 	}
 
-	public ApiResponse setOptionDefaultUserAgent(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionDefaultUserAgent(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionDefaultUserAgent", map);
 	}
 
-	public ApiResponse setOptionProxyChainName(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainName(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionProxyChainName", map);
 	}
 
-	public ApiResponse setOptionProxyChainPassword(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainPassword(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionProxyChainPassword", map);
 	}
 
-	public ApiResponse setOptionProxyChainRealm(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainRealm(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionProxyChainRealm", map);
 	}
 
-	public ApiResponse setOptionProxyChainSkipName(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainSkipName(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionProxyChainSkipName", map);
 	}
 
-	public ApiResponse setOptionProxyChainUserName(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainUserName(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionProxyChainUserName", map);
 	}
 
-	public ApiResponse setOptionHttpStateEnabled(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionHttpStateEnabled(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("core", "action", "setOptionHttpStateEnabled", map);
 	}
 
-	public ApiResponse setOptionProxyChainPort(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainPort(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("core", "action", "setOptionProxyChainPort", map);
 	}
 
-	public ApiResponse setOptionProxyChainPrompt(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProxyChainPrompt(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("core", "action", "setOptionProxyChainPrompt", map);
 	}
 
-	public ApiResponse setOptionSingleCookieRequestHeader(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionSingleCookieRequestHeader(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("core", "action", "setOptionSingleCookieRequestHeader", map);
 	}
 
-	public ApiResponse setOptionTimeoutInSecs(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionTimeoutInSecs(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("core", "action", "setOptionTimeoutInSecs", map);
 	}
 
-	public ApiResponse setOptionUseProxyChain(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionUseProxyChain(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("core", "action", "setOptionUseProxyChain", map);
 	}
 
-	public ApiResponse setOptionUseProxyChainAuth(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionUseProxyChainAuth(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("core", "action", "setOptionUseProxyChainAuth", map);
 	}
 
-	public byte[] proxypac(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("core", "other", "proxy.pac", map);
+	public byte[] proxypac() throws ClientApiException {
+		return api.callApiOther("core", "other", "proxy.pac", null);
 	}
 
-	public byte[] rootcert(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("core", "other", "rootcert", map);
+	public byte[] rootcert() throws ClientApiException {
+		return api.callApiOther("core", "other", "rootcert", null);
 	}
 
-	public byte[] setproxy(String apikey, String proxy) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] setproxy(String proxy) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("proxy", proxy);
 		return api.callApiOther("core", "other", "setproxy", map);
 	}
@@ -600,36 +441,22 @@ public class Core {
 	/**
 	 * Generates a report in XML format
 	 */
-	public byte[] xmlreport(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("core", "other", "xmlreport", map);
+	public byte[] xmlreport() throws ClientApiException {
+		return api.callApiOther("core", "other", "xmlreport", null);
 	}
 
 	/**
 	 * Generates a report in HTML format
 	 */
-	public byte[] htmlreport(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("core", "other", "htmlreport", map);
+	public byte[] htmlreport() throws ClientApiException {
+		return api.callApiOther("core", "other", "htmlreport", null);
 	}
 
 	/**
 	 * Gets the message with the given ID in HAR format
 	 */
-	public byte[] messageHar(String apikey, String id) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] messageHar(String id) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		return api.callApiOther("core", "other", "messageHar", map);
 	}
@@ -637,12 +464,8 @@ public class Core {
 	/**
 	 * Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 	 */
-	public byte[] messagesHar(String apikey, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] messagesHar(String baseurl, String start, String count) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
 		}
@@ -658,12 +481,8 @@ public class Core {
 	/**
 	 * Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any.
 	 */
-	public byte[] sendHarRequest(String apikey, String request, String followredirects) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] sendHarRequest(String request, String followredirects) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("request", request);
 		if (followredirects != null) {
 			map.put("followRedirects", followredirects);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ForcedUser.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ForcedUser.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class ForcedUser {
+@SuppressWarnings("javadoc")
+public class ForcedUser extends org.zaproxy.clientapi.gen.deprecated.ForcedUserDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public ForcedUser(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,16 +44,14 @@ public class ForcedUser {
 	 * Returns 'true' if 'forced user' mode is enabled, 'false' otherwise
 	 */
 	public ApiResponse isForcedUserModeEnabled() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("forcedUser", "view", "isForcedUserModeEnabled", map);
+		return api.callApi("forcedUser", "view", "isForcedUserModeEnabled", null);
 	}
 
 	/**
 	 * Gets the user (ID) set as 'forced user' for the given context (ID)
 	 */
 	public ApiResponse getForcedUser(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("forcedUser", "view", "getForcedUser", map);
 	}
@@ -59,12 +59,8 @@ public class ForcedUser {
 	/**
 	 * Sets the user (ID) that should be used in 'forced user' mode for the given context (ID)
 	 */
-	public ApiResponse setForcedUser(String apikey, String contextid, String userid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setForcedUser(String contextid, String userid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		return api.callApi("forcedUser", "action", "setForcedUser", map);
@@ -73,12 +69,8 @@ public class ForcedUser {
 	/**
 	 * Sets if 'forced user' mode should be enabled or not
 	 */
-	public ApiResponse setForcedUserModeEnabled(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setForcedUserModeEnabled(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("boolean", Boolean.toString(bool));
 		return api.callApi("forcedUser", "action", "setForcedUserModeEnabled", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class HttpSessions {
+@SuppressWarnings("javadoc")
+public class HttpSessions extends org.zaproxy.clientapi.gen.deprecated.HttpSessionsDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public HttpSessions(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,8 +44,7 @@ public class HttpSessions {
 	 * Gets the sessions of the given site. Optionally returning just the session with the given name.
 	 */
 	public ApiResponse sessions(String site, String session) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		if (session != null) {
 			map.put("session", session);
@@ -55,8 +56,7 @@ public class HttpSessions {
 	 * Gets the name of the active session for the given site.
 	 */
 	public ApiResponse activeSession(String site) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		return api.callApi("httpSessions", "view", "activeSession", map);
 	}
@@ -65,8 +65,7 @@ public class HttpSessions {
 	 * Gets the names of the session tokens for the given site.
 	 */
 	public ApiResponse sessionTokens(String site) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		return api.callApi("httpSessions", "view", "sessionTokens", map);
 	}
@@ -74,12 +73,8 @@ public class HttpSessions {
 	/**
 	 * Creates an empty session for the given site. Optionally with the given name.
 	 */
-	public ApiResponse createEmptySession(String apikey, String site, String session) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse createEmptySession(String site, String session) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		if (session != null) {
 			map.put("session", session);
@@ -90,12 +85,8 @@ public class HttpSessions {
 	/**
 	 * Removes the session from the given site.
 	 */
-	public ApiResponse removeSession(String apikey, String site, String session) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeSession(String site, String session) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		map.put("session", session);
 		return api.callApi("httpSessions", "action", "removeSession", map);
@@ -104,12 +95,8 @@ public class HttpSessions {
 	/**
 	 * Sets the given session as active for the given site.
 	 */
-	public ApiResponse setActiveSession(String apikey, String site, String session) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setActiveSession(String site, String session) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		map.put("session", session);
 		return api.callApi("httpSessions", "action", "setActiveSession", map);
@@ -118,12 +105,8 @@ public class HttpSessions {
 	/**
 	 * Unsets the active session of the given site.
 	 */
-	public ApiResponse unsetActiveSession(String apikey, String site) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse unsetActiveSession(String site) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		return api.callApi("httpSessions", "action", "unsetActiveSession", map);
 	}
@@ -131,12 +114,8 @@ public class HttpSessions {
 	/**
 	 * Adds the session token to the given site.
 	 */
-	public ApiResponse addSessionToken(String apikey, String site, String sessiontoken) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse addSessionToken(String site, String sessiontoken) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		map.put("sessionToken", sessiontoken);
 		return api.callApi("httpSessions", "action", "addSessionToken", map);
@@ -145,12 +124,8 @@ public class HttpSessions {
 	/**
 	 * Removes the session token from the given site.
 	 */
-	public ApiResponse removeSessionToken(String apikey, String site, String sessiontoken) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeSessionToken(String site, String sessiontoken) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		map.put("sessionToken", sessiontoken);
 		return api.callApi("httpSessions", "action", "removeSessionToken", map);
@@ -159,12 +134,8 @@ public class HttpSessions {
 	/**
 	 * Sets the value of the session token of the given session for the given site.
 	 */
-	public ApiResponse setSessionTokenValue(String apikey, String site, String session, String sessiontoken, String tokenvalue) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setSessionTokenValue(String site, String session, String sessiontoken, String tokenvalue) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		map.put("session", session);
 		map.put("sessionToken", sessiontoken);
@@ -175,12 +146,8 @@ public class HttpSessions {
 	/**
 	 * Renames the session of the given site.
 	 */
-	public ApiResponse renameSession(String apikey, String site, String oldsessionname, String newsessionname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse renameSession(String site, String oldsessionname, String newsessionname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		map.put("oldSessionName", oldsessionname);
 		map.put("newSessionName", newsessionname);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ImportLogFiles.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ImportLogFiles.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class ImportLogFiles {
+@SuppressWarnings("javadoc")
+public class ImportLogFiles extends org.zaproxy.clientapi.gen.deprecated.ImportLogFilesDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public ImportLogFiles(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,42 +44,35 @@ public class ImportLogFiles {
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public ApiResponse ImportZAPLogFromFile(String filepath) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("FilePath", filepath);
-		return api.callApi("importLogFiles", "view", "ImportZAPLogFromFile", map);
+		return api.callApi("importLogFiles", "action", "ImportZAPLogFromFile", map);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public ApiResponse ImportModSecurityLogFromFile(String filepath) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("FilePath", filepath);
-		return api.callApi("importLogFiles", "view", "ImportModSecurityLogFromFile", map);
+		return api.callApi("importLogFiles", "action", "ImportModSecurityLogFromFile", map);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public ApiResponse ImportZAPHttpRequestResponsePair(String httprequest, String httpresponse) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("HTTPRequest", httprequest);
 		map.put("HTTPResponse", httpresponse);
-		return api.callApi("importLogFiles", "view", "ImportZAPHttpRequestResponsePair", map);
+		return api.callApi("importLogFiles", "action", "ImportZAPHttpRequestResponsePair", map);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse PostModSecurityAuditEvent(String apikey, String auditeventstring) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse PostModSecurityAuditEvent(String auditeventstring) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (auditeventstring != null) {
 			map.put("AuditEventString", auditeventstring);
 		}
@@ -87,12 +82,8 @@ public class ImportLogFiles {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public byte[] OtherPostModSecurityAuditEvent(String apikey, String auditeventstring) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] OtherPostModSecurityAuditEvent(String auditeventstring) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("AuditEventString", auditeventstring);
 		return api.callApiOther("importLogFiles", "other", "OtherPostModSecurityAuditEvent", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Params.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Params.java
@@ -30,9 +30,10 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
+@SuppressWarnings("javadoc")
 public class Params {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Params(ClientApi api) {
 		this.api = api;
@@ -42,8 +43,7 @@ public class Params {
 	 * Shows the parameters for the specified site, or for all sites if the site is not specified
 	 */
 	public ApiResponse params(String site) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (site != null) {
 			map.put("site", site);
 		}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pnh.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pnh.java
@@ -30,23 +30,21 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Pnh {
+@SuppressWarnings("javadoc")
+public class Pnh extends org.zaproxy.clientapi.gen.deprecated.PnhDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Pnh(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse monitor(String apikey, String id, String message) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse monitor(String id, String message) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		map.put("message", message);
 		return api.callApi("pnh", "action", "monitor", map);
@@ -55,12 +53,8 @@ public class Pnh {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse oracle(String apikey, String id) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse oracle(String id) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		return api.callApi("pnh", "action", "oracle", map);
 	}
@@ -68,12 +62,8 @@ public class Pnh {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse startMonitoring(String apikey, String url) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse startMonitoring(String url) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("url", url);
 		return api.callApi("pnh", "action", "startMonitoring", map);
 	}
@@ -81,12 +71,8 @@ public class Pnh {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse stopMonitoring(String apikey, String id) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse stopMonitoring(String id) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		return api.callApi("pnh", "action", "stopMonitoring", map);
 	}
@@ -94,49 +80,29 @@ public class Pnh {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public byte[] pnh(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("pnh", "other", "pnh", map);
+	public byte[] pnh() throws ClientApiException {
+		return api.callApiOther("pnh", "other", "pnh", null);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public byte[] manifest(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("pnh", "other", "manifest", map);
+	public byte[] manifest() throws ClientApiException {
+		return api.callApiOther("pnh", "other", "manifest", null);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public byte[] service(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("pnh", "other", "service", map);
+	public byte[] service() throws ClientApiException {
+		return api.callApiOther("pnh", "other", "service", null);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public byte[] fx_pnhxpi(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApiOther("pnh", "other", "fx_pnh.xpi", map);
+	public byte[] fx_pnhxpi() throws ClientApiException {
+		return api.callApiOther("pnh", "other", "fx_pnh.xpi", null);
 	}
 
 }

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Pscan {
+@SuppressWarnings("javadoc")
+public class Pscan extends org.zaproxy.clientapi.gen.deprecated.PscanDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Pscan(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,27 +44,21 @@ public class Pscan {
 	 * The number of records the passive scanner still has to scan
 	 */
 	public ApiResponse recordsToScan() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("pscan", "view", "recordsToScan", map);
+		return api.callApi("pscan", "view", "recordsToScan", null);
 	}
 
 	/**
 	 * Lists all passive scanners with its ID, name, enabled state and alert threshold.
 	 */
 	public ApiResponse scanners() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("pscan", "view", "scanners", map);
+		return api.callApi("pscan", "view", "scanners", null);
 	}
 
 	/**
 	 * Sets whether or not the passive scanning is enabled
 	 */
-	public ApiResponse setEnabled(String apikey, String enabled) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setEnabled(String enabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("enabled", enabled);
 		return api.callApi("pscan", "action", "setEnabled", map);
 	}
@@ -70,36 +66,22 @@ public class Pscan {
 	/**
 	 * Enables all passive scanners
 	 */
-	public ApiResponse enableAllScanners(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("pscan", "action", "enableAllScanners", map);
+	public ApiResponse enableAllScanners() throws ClientApiException {
+		return api.callApi("pscan", "action", "enableAllScanners", null);
 	}
 
 	/**
 	 * Disables all passive scanners
 	 */
-	public ApiResponse disableAllScanners(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("pscan", "action", "disableAllScanners", map);
+	public ApiResponse disableAllScanners() throws ClientApiException {
+		return api.callApi("pscan", "action", "disableAllScanners", null);
 	}
 
 	/**
 	 * Enables all passive scanners with the given IDs (comma separated list of IDs)
 	 */
-	public ApiResponse enableScanners(String apikey, String ids) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse enableScanners(String ids) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("ids", ids);
 		return api.callApi("pscan", "action", "enableScanners", map);
 	}
@@ -107,12 +89,8 @@ public class Pscan {
 	/**
 	 * Disables all passive scanners with the given IDs (comma separated list of IDs)
 	 */
-	public ApiResponse disableScanners(String apikey, String ids) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse disableScanners(String ids) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("ids", ids);
 		return api.callApi("pscan", "action", "disableScanners", map);
 	}
@@ -120,12 +98,8 @@ public class Pscan {
 	/**
 	 * Sets the alert threshold of the passive scanner with the given ID, accepted values for alert threshold: OFF, DEFAULT, LOW, MEDIUM and HIGH
 	 */
-	public ApiResponse setScannerAlertThreshold(String apikey, String id, String alertthreshold) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setScannerAlertThreshold(String id, String alertthreshold) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("id", id);
 		map.put("alertThreshold", alertthreshold);
 		return api.callApi("pscan", "action", "setScannerAlertThreshold", map);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Reveal.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Reveal.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Reveal {
+@SuppressWarnings("javadoc")
+public class Reveal extends org.zaproxy.clientapi.gen.deprecated.RevealDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Reveal(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,19 +44,14 @@ public class Reveal {
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public ApiResponse reveal() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("reveal", "view", "reveal", map);
+		return api.callApi("reveal", "view", "reveal", null);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setReveal(String apikey, String reveal) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setReveal(String reveal) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("reveal", reveal);
 		return api.callApi("reveal", "action", "setReveal", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Script.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Script.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Script {
+@SuppressWarnings("javadoc")
+public class Script extends org.zaproxy.clientapi.gen.deprecated.ScriptDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Script(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,27 +44,21 @@ public class Script {
 	 * Lists the script engines available
 	 */
 	public ApiResponse listEngines() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("script", "view", "listEngines", map);
+		return api.callApi("script", "view", "listEngines", null);
 	}
 
 	/**
 	 * Lists the scripts available, with its engine, name, description, type and error state.
 	 */
 	public ApiResponse listScripts() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("script", "view", "listScripts", map);
+		return api.callApi("script", "view", "listScripts", null);
 	}
 
 	/**
 	 * Enables the script with the given name
 	 */
-	public ApiResponse enable(String apikey, String scriptname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse enable(String scriptname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scriptName", scriptname);
 		return api.callApi("script", "action", "enable", map);
 	}
@@ -70,12 +66,8 @@ public class Script {
 	/**
 	 * Disables the script with the given name
 	 */
-	public ApiResponse disable(String apikey, String scriptname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse disable(String scriptname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scriptName", scriptname);
 		return api.callApi("script", "action", "disable", map);
 	}
@@ -83,12 +75,8 @@ public class Script {
 	/**
 	 * Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description
 	 */
-	public ApiResponse load(String apikey, String scriptname, String scripttype, String scriptengine, String filename, String scriptdescription) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse load(String scriptname, String scripttype, String scriptengine, String filename, String scriptdescription) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scriptName", scriptname);
 		map.put("scriptType", scripttype);
 		map.put("scriptEngine", scriptengine);
@@ -102,12 +90,8 @@ public class Script {
 	/**
 	 * Removes the script with the given name
 	 */
-	public ApiResponse remove(String apikey, String scriptname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse remove(String scriptname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scriptName", scriptname);
 		return api.callApi("script", "action", "remove", map);
 	}
@@ -115,12 +99,8 @@ public class Script {
 	/**
 	 * Runs the stand alone script with the give name
 	 */
-	public ApiResponse runStandAloneScript(String apikey, String scriptname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse runStandAloneScript(String scriptname) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scriptName", scriptname);
 		return api.callApi("script", "action", "runStandAloneScript", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Search.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Search.java
@@ -30,17 +30,18 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Search {
+@SuppressWarnings("javadoc")
+public class Search extends org.zaproxy.clientapi.gen.deprecated.SearchDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Search(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	public ApiResponse urlsByUrlRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -55,8 +56,7 @@ public class Search {
 	}
 
 	public ApiResponse urlsByRequestRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -71,8 +71,7 @@ public class Search {
 	}
 
 	public ApiResponse urlsByResponseRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -87,8 +86,7 @@ public class Search {
 	}
 
 	public ApiResponse urlsByHeaderRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -103,8 +101,7 @@ public class Search {
 	}
 
 	public ApiResponse messagesByUrlRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -119,8 +116,7 @@ public class Search {
 	}
 
 	public ApiResponse messagesByRequestRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -135,8 +131,7 @@ public class Search {
 	}
 
 	public ApiResponse messagesByResponseRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -151,8 +146,7 @@ public class Search {
 	}
 
 	public ApiResponse messagesByHeaderRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -166,12 +160,8 @@ public class Search {
 		return api.callApi("search", "view", "messagesByHeaderRegex", map);
 	}
 
-	public byte[] harByUrlRegex(String apikey, String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] harByUrlRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -185,12 +175,8 @@ public class Search {
 		return api.callApiOther("search", "other", "harByUrlRegex", map);
 	}
 
-	public byte[] harByRequestRegex(String apikey, String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] harByRequestRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -204,12 +190,8 @@ public class Search {
 		return api.callApiOther("search", "other", "harByRequestRegex", map);
 	}
 
-	public byte[] harByResponseRegex(String apikey, String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] harByResponseRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -223,12 +205,8 @@ public class Search {
 		return api.callApiOther("search", "other", "harByResponseRegex", map);
 	}
 
-	public byte[] harByHeaderRegex(String apikey, String regex, String baseurl, String start, String count) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public byte[] harByHeaderRegex(String regex, String baseurl, String start, String count) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Selenium.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Selenium.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Selenium {
+@SuppressWarnings("javadoc")
+public class Selenium extends org.zaproxy.clientapi.gen.deprecated.SeleniumDeprecated {
 
 	private final ClientApi api;
 
 	public Selenium(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -88,11 +90,8 @@ public class Selenium {
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionChromeDriverPath(String apikey, String string) throws ClientApiException {
+	public ApiResponse setOptionChromeDriverPath(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("String", string);
 		return api.callApi("selenium", "action", "setOptionChromeDriverPath", map);
 	}
@@ -102,11 +101,8 @@ public class Selenium {
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionFirefoxBinaryPath(String apikey, String string) throws ClientApiException {
+	public ApiResponse setOptionFirefoxBinaryPath(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("String", string);
 		return api.callApi("selenium", "action", "setOptionFirefoxBinaryPath", map);
 	}
@@ -116,11 +112,8 @@ public class Selenium {
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionFirefoxDriverPath(String apikey, String string) throws ClientApiException {
+	public ApiResponse setOptionFirefoxDriverPath(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("String", string);
 		return api.callApi("selenium", "action", "setOptionFirefoxDriverPath", map);
 	}
@@ -130,11 +123,8 @@ public class Selenium {
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionIeDriverPath(String apikey, String string) throws ClientApiException {
+	public ApiResponse setOptionIeDriverPath(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("String", string);
 		return api.callApi("selenium", "action", "setOptionIeDriverPath", map);
 	}
@@ -144,11 +134,8 @@ public class Selenium {
 	 * <p>
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public ApiResponse setOptionPhantomJsBinaryPath(String apikey, String string) throws ClientApiException {
+	public ApiResponse setOptionPhantomJsBinaryPath(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
 		map.put("String", string);
 		return api.callApi("selenium", "action", "setOptionPhantomJsBinaryPath", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/SessionManagement.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/SessionManagement.java
@@ -30,39 +30,34 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class SessionManagement {
+@SuppressWarnings("javadoc")
+public class SessionManagement extends org.zaproxy.clientapi.gen.deprecated.SessionManagementDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public SessionManagement(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	public ApiResponse getSupportedSessionManagementMethods() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("sessionManagement", "view", "getSupportedSessionManagementMethods", map);
+		return api.callApi("sessionManagement", "view", "getSupportedSessionManagementMethods", null);
 	}
 
 	public ApiResponse getSessionManagementMethodConfigParams(String methodname) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("methodName", methodname);
 		return api.callApi("sessionManagement", "view", "getSessionManagementMethodConfigParams", map);
 	}
 
 	public ApiResponse getSessionManagementMethod(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("sessionManagement", "view", "getSessionManagementMethod", map);
 	}
 
-	public ApiResponse setSessionManagementMethod(String apikey, String contextid, String methodname, String methodconfigparams) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setSessionManagementMethod(String contextid, String methodname, String methodconfigparams) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("methodName", methodname);
 		if (methodconfigparams != null) {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
@@ -30,17 +30,18 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Spider {
+@SuppressWarnings("javadoc")
+public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Spider(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	public ApiResponse status(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (scanid != null) {
 			map.put("scanId", scanid);
 		}
@@ -48,8 +49,7 @@ public class Spider {
 	}
 
 	public ApiResponse results(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (scanid != null) {
 			map.put("scanId", scanid);
 		}
@@ -57,144 +57,115 @@ public class Spider {
 	}
 
 	public ApiResponse fullResults(String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("spider", "view", "fullResults", map);
 	}
 
 	public ApiResponse scans() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "scans", map);
+		return api.callApi("spider", "view", "scans", null);
 	}
 
 	public ApiResponse excludedFromScan() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "excludedFromScan", map);
+		return api.callApi("spider", "view", "excludedFromScan", null);
 	}
 
 	public ApiResponse optionDomainsAlwaysInScope() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionDomainsAlwaysInScope", map);
+		return api.callApi("spider", "view", "optionDomainsAlwaysInScope", null);
 	}
 
 	public ApiResponse optionDomainsAlwaysInScopeEnabled() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionDomainsAlwaysInScopeEnabled", map);
+		return api.callApi("spider", "view", "optionDomainsAlwaysInScopeEnabled", null);
 	}
 
 	public ApiResponse optionHandleParameters() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionHandleParameters", map);
+		return api.callApi("spider", "view", "optionHandleParameters", null);
 	}
 
 	public ApiResponse optionMaxDepth() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionMaxDepth", map);
+		return api.callApi("spider", "view", "optionMaxDepth", null);
 	}
 
 	public ApiResponse optionMaxDuration() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionMaxDuration", map);
+		return api.callApi("spider", "view", "optionMaxDuration", null);
 	}
 
 	public ApiResponse optionMaxScansInUI() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionMaxScansInUI", map);
+		return api.callApi("spider", "view", "optionMaxScansInUI", null);
 	}
 
 	public ApiResponse optionRequestWaitTime() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionRequestWaitTime", map);
+		return api.callApi("spider", "view", "optionRequestWaitTime", null);
 	}
 
 	public ApiResponse optionScope() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionScope", map);
+		return api.callApi("spider", "view", "optionScope", null);
 	}
 
 	public ApiResponse optionScopeText() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionScopeText", map);
+		return api.callApi("spider", "view", "optionScopeText", null);
 	}
 
 	public ApiResponse optionSkipURLString() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionSkipURLString", map);
+		return api.callApi("spider", "view", "optionSkipURLString", null);
 	}
 
 	public ApiResponse optionThreadCount() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionThreadCount", map);
+		return api.callApi("spider", "view", "optionThreadCount", null);
 	}
 
 	public ApiResponse optionUserAgent() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionUserAgent", map);
+		return api.callApi("spider", "view", "optionUserAgent", null);
 	}
 
 	public ApiResponse optionHandleODataParametersVisited() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionHandleODataParametersVisited", map);
+		return api.callApi("spider", "view", "optionHandleODataParametersVisited", null);
 	}
 
 	public ApiResponse optionParseComments() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionParseComments", map);
+		return api.callApi("spider", "view", "optionParseComments", null);
 	}
 
 	public ApiResponse optionParseGit() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionParseGit", map);
+		return api.callApi("spider", "view", "optionParseGit", null);
 	}
 
 	public ApiResponse optionParseRobotsTxt() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionParseRobotsTxt", map);
+		return api.callApi("spider", "view", "optionParseRobotsTxt", null);
 	}
 
 	public ApiResponse optionParseSVNEntries() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionParseSVNEntries", map);
+		return api.callApi("spider", "view", "optionParseSVNEntries", null);
 	}
 
 	public ApiResponse optionParseSitemapXml() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionParseSitemapXml", map);
+		return api.callApi("spider", "view", "optionParseSitemapXml", null);
 	}
 
 	public ApiResponse optionPostForm() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionPostForm", map);
+		return api.callApi("spider", "view", "optionPostForm", null);
 	}
 
 	public ApiResponse optionProcessForm() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionProcessForm", map);
+		return api.callApi("spider", "view", "optionProcessForm", null);
 	}
 
 	/**
 	 * Sets whether or not the 'Referer' header should be sent while spidering
 	 */
 	public ApiResponse optionSendRefererHeader() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionSendRefererHeader", map);
+		return api.callApi("spider", "view", "optionSendRefererHeader", null);
 	}
 
 	public ApiResponse optionShowAdvancedDialog() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("spider", "view", "optionShowAdvancedDialog", map);
+		return api.callApi("spider", "view", "optionShowAdvancedDialog", null);
 	}
 
 	/**
 	 * Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 	 */
-	public ApiResponse scan(String apikey, String url, String maxchildren, String recurse, String contextname, String subtreeonly) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse scan(String url, String maxchildren, String recurse, String contextname, String subtreeonly) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (url != null) {
 			map.put("url", url);
 		}
@@ -216,12 +187,8 @@ public class Spider {
 	/**
 	 * Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 	 */
-	public ApiResponse scanAsUser(String apikey, String contextid, String userid, String url, String maxchildren, String recurse, String subtreeonly) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse scanAsUser(String contextid, String userid, String url, String maxchildren, String recurse, String subtreeonly) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		if (url != null) {
@@ -239,289 +206,168 @@ public class Spider {
 		return api.callApi("spider", "action", "scanAsUser", map);
 	}
 
-	public ApiResponse pause(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse pause(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("spider", "action", "pause", map);
 	}
 
-	public ApiResponse resume(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse resume(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("spider", "action", "resume", map);
 	}
 
-	public ApiResponse stop(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse stop(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (scanid != null) {
 			map.put("scanId", scanid);
 		}
 		return api.callApi("spider", "action", "stop", map);
 	}
 
-	public ApiResponse removeScan(String apikey, String scanid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeScan(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("spider", "action", "removeScan", map);
 	}
 
-	public ApiResponse pauseAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("spider", "action", "pauseAllScans", map);
+	public ApiResponse pauseAllScans() throws ClientApiException {
+		return api.callApi("spider", "action", "pauseAllScans", null);
 	}
 
-	public ApiResponse resumeAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("spider", "action", "resumeAllScans", map);
+	public ApiResponse resumeAllScans() throws ClientApiException {
+		return api.callApi("spider", "action", "resumeAllScans", null);
 	}
 
-	public ApiResponse stopAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("spider", "action", "stopAllScans", map);
+	public ApiResponse stopAllScans() throws ClientApiException {
+		return api.callApi("spider", "action", "stopAllScans", null);
 	}
 
-	public ApiResponse removeAllScans(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("spider", "action", "removeAllScans", map);
+	public ApiResponse removeAllScans() throws ClientApiException {
+		return api.callApi("spider", "action", "removeAllScans", null);
 	}
 
-	public ApiResponse clearExcludedFromScan(String apikey) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
-		return api.callApi("spider", "action", "clearExcludedFromScan", map);
+	public ApiResponse clearExcludedFromScan() throws ClientApiException {
+		return api.callApi("spider", "action", "clearExcludedFromScan", null);
 	}
 
-	public ApiResponse excludeFromScan(String apikey, String regex) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse excludeFromScan(String regex) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		return api.callApi("spider", "action", "excludeFromScan", map);
 	}
 
-	public ApiResponse setOptionHandleParameters(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionHandleParameters(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("spider", "action", "setOptionHandleParameters", map);
 	}
 
-	public ApiResponse setOptionScopeString(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionScopeString(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("spider", "action", "setOptionScopeString", map);
 	}
 
-	public ApiResponse setOptionSkipURLString(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionSkipURLString(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("spider", "action", "setOptionSkipURLString", map);
 	}
 
-	public ApiResponse setOptionUserAgent(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionUserAgent(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("spider", "action", "setOptionUserAgent", map);
 	}
 
-	public ApiResponse setOptionHandleODataParametersVisited(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionHandleODataParametersVisited(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionHandleODataParametersVisited", map);
 	}
 
-	public ApiResponse setOptionMaxDepth(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionMaxDepth(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("spider", "action", "setOptionMaxDepth", map);
 	}
 
-	public ApiResponse setOptionMaxDuration(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionMaxDuration(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("spider", "action", "setOptionMaxDuration", map);
 	}
 
-	public ApiResponse setOptionMaxScansInUI(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionMaxScansInUI(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("spider", "action", "setOptionMaxScansInUI", map);
 	}
 
-	public ApiResponse setOptionParseComments(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionParseComments(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionParseComments", map);
 	}
 
-	public ApiResponse setOptionParseGit(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionParseGit(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionParseGit", map);
 	}
 
-	public ApiResponse setOptionParseRobotsTxt(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionParseRobotsTxt(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionParseRobotsTxt", map);
 	}
 
-	public ApiResponse setOptionParseSVNEntries(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionParseSVNEntries(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionParseSVNEntries", map);
 	}
 
-	public ApiResponse setOptionParseSitemapXml(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionParseSitemapXml(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionParseSitemapXml", map);
 	}
 
-	public ApiResponse setOptionPostForm(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionPostForm(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionPostForm", map);
 	}
 
-	public ApiResponse setOptionProcessForm(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionProcessForm(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionProcessForm", map);
 	}
 
-	public ApiResponse setOptionRequestWaitTime(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionRequestWaitTime(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("spider", "action", "setOptionRequestWaitTime", map);
 	}
 
-	public ApiResponse setOptionSendRefererHeader(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionSendRefererHeader(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionSendRefererHeader", map);
 	}
 
-	public ApiResponse setOptionShowAdvancedDialog(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionShowAdvancedDialog(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionShowAdvancedDialog", map);
 	}
 
-	public ApiResponse setOptionThreadCount(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionThreadCount(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("spider", "action", "setOptionThreadCount", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Stats.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Stats.java
@@ -30,11 +30,13 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Stats {
+@SuppressWarnings("javadoc")
+public class Stats extends org.zaproxy.clientapi.gen.deprecated.StatsDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Stats(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
@@ -42,8 +44,7 @@ public class Stats {
 	 * Statistics
 	 */
 	public ApiResponse stats(String keyprefix) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (keyprefix != null) {
 			map.put("keyPrefix", keyprefix);
 		}
@@ -54,8 +55,7 @@ public class Stats {
 	 * Gets all of the site based statistics, optionally filtered by a key prefix
 	 */
 	public ApiResponse allSitesStats(String keyprefix) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (keyprefix != null) {
 			map.put("keyPrefix", keyprefix);
 		}
@@ -66,8 +66,7 @@ public class Stats {
 	 * Gets all of the global statistics, optionally filtered by a key prefix
 	 */
 	public ApiResponse siteStats(String site, String keyprefix) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("site", site);
 		if (keyprefix != null) {
 			map.put("keyPrefix", keyprefix);
@@ -79,51 +78,42 @@ public class Stats {
 	 * Gets the Statsd service hostname
 	 */
 	public ApiResponse optionStatsdHost() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("stats", "view", "optionStatsdHost", map);
+		return api.callApi("stats", "view", "optionStatsdHost", null);
 	}
 
 	/**
 	 * Gets the Statsd service port
 	 */
 	public ApiResponse optionStatsdPort() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("stats", "view", "optionStatsdPort", map);
+		return api.callApi("stats", "view", "optionStatsdPort", null);
 	}
 
 	/**
 	 * Gets the prefix to be applied to all stats sent to the configured Statsd service
 	 */
 	public ApiResponse optionStatsdPrefix() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("stats", "view", "optionStatsdPrefix", map);
+		return api.callApi("stats", "view", "optionStatsdPrefix", null);
 	}
 
 	/**
 	 * Returns 'true' if in memory statistics are enabled, otherwise returns 'false'
 	 */
 	public ApiResponse optionInMemoryEnabled() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("stats", "view", "optionInMemoryEnabled", map);
+		return api.callApi("stats", "view", "optionInMemoryEnabled", null);
 	}
 
 	/**
 	 * Returns 'true' if a Statsd server has been correctly configured, otherwise returns 'false'
 	 */
 	public ApiResponse optionStatsdEnabled() throws ClientApiException {
-		Map<String, String> map = null;
-		return api.callApi("stats", "view", "optionStatsdEnabled", map);
+		return api.callApi("stats", "view", "optionStatsdEnabled", null);
 	}
 
 	/**
 	 * Clears all of the statistics
 	 */
-	public ApiResponse clearStats(String apikey, String keyprefix) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse clearStats(String keyprefix) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		if (keyprefix != null) {
 			map.put("keyPrefix", keyprefix);
 		}
@@ -133,12 +123,8 @@ public class Stats {
 	/**
 	 * Sets the Statsd service hostname, supply an empty string to stop using a Statsd service
 	 */
-	public ApiResponse setOptionStatsdHost(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionStatsdHost(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("stats", "action", "setOptionStatsdHost", map);
 	}
@@ -146,12 +132,8 @@ public class Stats {
 	/**
 	 * Sets the prefix to be applied to all stats sent to the configured Statsd service
 	 */
-	public ApiResponse setOptionStatsdPrefix(String apikey, String string) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionStatsdPrefix(String string) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("stats", "action", "setOptionStatsdPrefix", map);
 	}
@@ -159,12 +141,8 @@ public class Stats {
 	/**
 	 * Sets whether in memory statistics are enabled
 	 */
-	public ApiResponse setOptionInMemoryEnabled(String apikey, boolean bool) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionInMemoryEnabled(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("stats", "action", "setOptionInMemoryEnabled", map);
 	}
@@ -172,12 +150,8 @@ public class Stats {
 	/**
 	 * Sets the Statsd service port
 	 */
-	public ApiResponse setOptionStatsdPort(String apikey, int i) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setOptionStatsdPort(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("stats", "action", "setOptionStatsdPort", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Users.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Users.java
@@ -30,17 +30,18 @@ import org.zaproxy.clientapi.core.ClientApiException;
 /**
  * This file was automatically generated.
  */
-public class Users {
+@SuppressWarnings("javadoc")
+public class Users extends org.zaproxy.clientapi.gen.deprecated.UsersDeprecated {
 
-	private ClientApi api = null;
+	private final ClientApi api;
 
 	public Users(ClientApi api) {
+		super(api);
 		this.api = api;
 	}
 
 	public ApiResponse usersList(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (contextid != null) {
 			map.put("contextId", contextid);
 		}
@@ -48,8 +49,7 @@ public class Users {
 	}
 
 	public ApiResponse getUserById(String contextid, String userid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		if (contextid != null) {
 			map.put("contextId", contextid);
 		}
@@ -60,72 +60,50 @@ public class Users {
 	}
 
 	public ApiResponse getAuthenticationCredentialsConfigParams(String contextid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		return api.callApi("users", "view", "getAuthenticationCredentialsConfigParams", map);
 	}
 
 	public ApiResponse getAuthenticationCredentials(String contextid, String userid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		return api.callApi("users", "view", "getAuthenticationCredentials", map);
 	}
 
-	public ApiResponse newUser(String apikey, String contextid, String name) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse newUser(String contextid, String name) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("name", name);
 		return api.callApi("users", "action", "newUser", map);
 	}
 
-	public ApiResponse removeUser(String apikey, String contextid, String userid) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse removeUser(String contextid, String userid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		return api.callApi("users", "action", "removeUser", map);
 	}
 
-	public ApiResponse setUserEnabled(String apikey, String contextid, String userid, String enabled) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setUserEnabled(String contextid, String userid, String enabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		map.put("enabled", enabled);
 		return api.callApi("users", "action", "setUserEnabled", map);
 	}
 
-	public ApiResponse setUserName(String apikey, String contextid, String userid, String name) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setUserName(String contextid, String userid, String name) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		map.put("name", name);
 		return api.callApi("users", "action", "setUserName", map);
 	}
 
-	public ApiResponse setAuthenticationCredentials(String apikey, String contextid, String userid, String authcredentialsconfigparams) throws ClientApiException {
-		Map<String, String> map = null;
-		map = new HashMap<String, String>();
-		if (apikey != null) {
-			map.put("apikey", apikey);
-		}
+	public ApiResponse setAuthenticationCredentials(String contextid, String userid, String authcredentialsconfigparams) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
 		map.put("contextId", contextid);
 		map.put("userId", userid);
 		if (authcredentialsconfigparams != null) {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AcsrfDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AcsrfDeprecated.java
@@ -1,0 +1,83 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class AcsrfDeprecated {
+
+    private final ClientApi api;
+
+    public AcsrfDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse addOptionToken(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("acsrf", "action", "addOptionToken", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeOptionToken(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("acsrf", "action", "removeOptionToken", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] genForm(String apikey, String hrefid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("hrefId", hrefid);
+        return api.callApiOther("acsrf", "other", "genForm", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AjaxSpiderDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AjaxSpiderDeprecated.java
@@ -1,0 +1,236 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class AjaxSpiderDeprecated {
+
+    private final ClientApi api;
+
+    public AjaxSpiderDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed.
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse scan(String apikey, String url, String inscope) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (url != null) {
+            map.put("url", url);
+        }
+        if (inscope != null) {
+            map.put("inScope", inscope);
+        }
+        return api.callApi("ajaxSpider", "action", "scan", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse stop(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("ajaxSpider", "action", "stop", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionBrowserId(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("ajaxSpider", "action", "setOptionBrowserId", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionClickDefaultElems(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ajaxSpider", "action", "setOptionClickDefaultElems", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionClickElemsOnce(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ajaxSpider", "action", "setOptionClickElemsOnce", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionEventWait(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ajaxSpider", "action", "setOptionEventWait", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxCrawlDepth(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ajaxSpider", "action", "setOptionMaxCrawlDepth", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxCrawlStates(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ajaxSpider", "action", "setOptionMaxCrawlStates", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxDuration(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ajaxSpider", "action", "setOptionMaxDuration", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionNumberOfBrowsers(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ajaxSpider", "action", "setOptionNumberOfBrowsers", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionRandomInputs(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ajaxSpider", "action", "setOptionRandomInputs", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionReloadWait(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ajaxSpider", "action", "setOptionReloadWait", map);
+    }
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AscanDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AscanDeprecated.java
@@ -1,0 +1,687 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class AscanDeprecated {
+
+    private final ClientApi api;
+
+    public AscanDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse scan(
+            String apikey,
+            String url,
+            String recurse,
+            String inscopeonly,
+            String scanpolicyname,
+            String method,
+            String postdata) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("url", url);
+        if (recurse != null) {
+            map.put("recurse", recurse);
+        }
+        if (inscopeonly != null) {
+            map.put("inScopeOnly", inscopeonly);
+        }
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        if (method != null) {
+            map.put("method", method);
+        }
+        if (postdata != null) {
+            map.put("postData", postdata);
+        }
+        return api.callApi("ascan", "action", "scan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse scanAsUser(
+            String apikey,
+            String url,
+            String contextid,
+            String userid,
+            String recurse,
+            String scanpolicyname,
+            String method,
+            String postdata) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("url", url);
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        if (recurse != null) {
+            map.put("recurse", recurse);
+        }
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        if (method != null) {
+            map.put("method", method);
+        }
+        if (postdata != null) {
+            map.put("postData", postdata);
+        }
+        return api.callApi("ascan", "action", "scanAsUser", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse pause(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("ascan", "action", "pause", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse resume(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("ascan", "action", "resume", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse stop(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("ascan", "action", "stop", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeScan(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("ascan", "action", "removeScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse pauseAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("ascan", "action", "pauseAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse resumeAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("ascan", "action", "resumeAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse stopAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("ascan", "action", "stopAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("ascan", "action", "removeAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse clearExcludedFromScan(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("ascan", "action", "clearExcludedFromScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse excludeFromScan(String apikey, String regex) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        return api.callApi("ascan", "action", "excludeFromScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse enableAllScanners(String apikey, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "enableAllScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse disableAllScanners(String apikey, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "disableAllScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse enableScanners(String apikey, String ids, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("ids", ids);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "enableScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse disableScanners(String apikey, String ids, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("ids", ids);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "disableScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setEnabledPolicies(String apikey, String ids, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("ids", ids);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "setEnabledPolicies", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setPolicyAttackStrength(String apikey, String id, String attackstrength, String scanpolicyname)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        map.put("attackStrength", attackstrength);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "setPolicyAttackStrength", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setPolicyAlertThreshold(String apikey, String id, String alertthreshold, String scanpolicyname)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        map.put("alertThreshold", alertthreshold);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "setPolicyAlertThreshold", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setScannerAttackStrength(String apikey, String id, String attackstrength, String scanpolicyname)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        map.put("attackStrength", attackstrength);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "setScannerAttackStrength", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setScannerAlertThreshold(String apikey, String id, String alertthreshold, String scanpolicyname)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        map.put("alertThreshold", alertthreshold);
+        if (scanpolicyname != null) {
+            map.put("scanPolicyName", scanpolicyname);
+        }
+        return api.callApi("ascan", "action", "setScannerAlertThreshold", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse addScanPolicy(String apikey, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanPolicyName", scanpolicyname);
+        return api.callApi("ascan", "action", "addScanPolicy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeScanPolicy(String apikey, String scanpolicyname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanPolicyName", scanpolicyname);
+        return api.callApi("ascan", "action", "removeScanPolicy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionAttackPolicy(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("ascan", "action", "setOptionAttackPolicy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionDefaultPolicy(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("ascan", "action", "setOptionDefaultPolicy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionAllowAttackOnStart(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionAllowAttackOnStart", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionDelayInMs(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionDelayInMs", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionHandleAntiCSRFTokens(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionHandleAntiCSRFTokens", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionHostPerScan(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionHostPerScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionInjectPluginIdInHeader(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionInjectPluginIdInHeader", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxChartTimeInMins(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionMaxChartTimeInMins", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxResultsToList(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionMaxResultsToList", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxScansInUI(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionMaxScansInUI", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionPromptInAttackMode(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionPromptInAttackMode", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionPromptToClearFinishedScans(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionPromptToClearFinishedScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionRescanInAttackMode(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionRescanInAttackMode", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionScanHeadersAllRequests(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionScanHeadersAllRequests", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionShowAdvancedDialog(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("ascan", "action", "setOptionShowAdvancedDialog", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionTargetParamsEnabledRPC(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionTargetParamsEnabledRPC", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionTargetParamsInjectable(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionTargetParamsInjectable", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionThreadPerHost(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("ascan", "action", "setOptionThreadPerHost", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthenticationDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthenticationDeprecated.java
@@ -1,0 +1,95 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class AuthenticationDeprecated {
+
+    private final ClientApi api;
+
+    public AuthenticationDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setAuthenticationMethod(
+            String apikey,
+            String contextid,
+            String authmethodname,
+            String authmethodconfigparams) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("authMethodName", authmethodname);
+        if (authmethodconfigparams != null) {
+            map.put("authMethodConfigParams", authmethodconfigparams);
+        }
+        return api.callApi("authentication", "action", "setAuthenticationMethod", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setLoggedInIndicator(String apikey, String contextid, String loggedinindicatorregex)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("loggedInIndicatorRegex", loggedinindicatorregex);
+        return api.callApi("authentication", "action", "setLoggedInIndicator", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setLoggedOutIndicator(String apikey, String contextid, String loggedoutindicatorregex)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("loggedOutIndicatorRegex", loggedoutindicatorregex);
+        return api.callApi("authentication", "action", "setLoggedOutIndicator", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthorizationDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthorizationDeprecated.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class AuthorizationDeprecated {
+
+    private final ClientApi api;
+
+    public AuthorizationDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setBasicAuthorizationDetectionMethod(
+            String apikey,
+            String contextid,
+            String headerregex,
+            String bodyregex,
+            String statuscode,
+            String logicaloperator) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        if (headerregex != null) {
+            map.put("headerRegex", headerregex);
+        }
+        if (bodyregex != null) {
+            map.put("bodyRegex", bodyregex);
+        }
+        if (statuscode != null) {
+            map.put("statusCode", statuscode);
+        }
+        if (logicaloperator != null) {
+            map.put("logicalOperator", logicaloperator);
+        }
+        return api.callApi("authorization", "action", "setBasicAuthorizationDetectionMethod", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AutoupdateDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AutoupdateDeprecated.java
@@ -1,0 +1,166 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class AutoupdateDeprecated {
+
+    private final ClientApi api;
+
+    public AutoupdateDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse downloadLatestRelease(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("autoupdate", "action", "downloadLatestRelease", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionCheckAddonUpdates(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionCheckAddonUpdates", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionCheckOnStart(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionCheckOnStart", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionDownloadNewRelease(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionDownloadNewRelease", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionInstallAddonUpdates(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionInstallAddonUpdates", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionInstallScannerRules(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionInstallScannerRules", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionReportAlphaAddons(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionReportAlphaAddons", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionReportBetaAddons(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionReportBetaAddons", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionReportReleaseAddons(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("autoupdate", "action", "setOptionReportReleaseAddons", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/BreakDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/BreakDeprecated.java
@@ -1,0 +1,105 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class BreakDeprecated {
+
+    private final ClientApi api;
+
+    public BreakDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse brk(String apikey, String type, String scope, String state) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("type", type);
+        map.put("scope", scope);
+        map.put("state", state);
+        return api.callApi("break", "action", "break", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse addHttpBreakpoint(
+            String apikey,
+            String string,
+            String location,
+            String match,
+            String inverse,
+            String ignorecase) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("string", string);
+        map.put("location", location);
+        map.put("match", match);
+        map.put("inverse", inverse);
+        map.put("ignorecase", ignorecase);
+        return api.callApi("break", "action", "addHttpBreakpoint", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeHttpBreakpoint(
+            String apikey,
+            String string,
+            String location,
+            String match,
+            String inverse,
+            String ignorecase) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("string", string);
+        map.put("location", location);
+        map.put("match", match);
+        map.put("inverse", inverse);
+        map.put("ignorecase", ignorecase);
+        return api.callApi("break", "action", "removeHttpBreakpoint", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ContextDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ContextDeprecated.java
@@ -1,0 +1,203 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class ContextDeprecated {
+
+    private final ClientApi api;
+
+    public ContextDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse excludeFromContext(String apikey, String contextname, String regex) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        map.put("regex", regex);
+        return api.callApi("context", "action", "excludeFromContext", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse includeInContext(String apikey, String contextname, String regex) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        map.put("regex", regex);
+        return api.callApi("context", "action", "includeInContext", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse newContext(String apikey, String contextname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        return api.callApi("context", "action", "newContext", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeContext(String apikey, String contextname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        return api.callApi("context", "action", "removeContext", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse exportContext(String apikey, String contextname, String contextfile) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        map.put("contextFile", contextfile);
+        return api.callApi("context", "action", "exportContext", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse importContext(String apikey, String contextfile) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextFile", contextfile);
+        return api.callApi("context", "action", "importContext", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse includeContextTechnologies(String apikey, String contextname, String technologynames)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        map.put("technologyNames", technologynames);
+        return api.callApi("context", "action", "includeContextTechnologies", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse includeAllContextTechnologies(String apikey, String contextname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        return api.callApi("context", "action", "includeAllContextTechnologies", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse excludeContextTechnologies(String apikey, String contextname, String technologynames)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        map.put("technologyNames", technologynames);
+        return api.callApi("context", "action", "excludeContextTechnologies", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse excludeAllContextTechnologies(String apikey, String contextname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        return api.callApi("context", "action", "excludeAllContextTechnologies", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setContextInScope(String apikey, String contextname, String booleaninscope) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextName", contextname);
+        map.put("booleanInScope", booleaninscope);
+        return api.callApi("context", "action", "setContextInScope", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/CoreDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/CoreDeprecated.java
@@ -1,0 +1,566 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class CoreDeprecated {
+
+    private final ClientApi api;
+
+    public CoreDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse accessUrl(String apikey, String url, String followredirects) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("url", url);
+        if (followredirects != null) {
+            map.put("followRedirects", followredirects);
+        }
+        return api.callApi("core", "action", "accessUrl", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse shutdown(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("core", "action", "shutdown", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse newSession(String apikey, String name, String overwrite) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (name != null) {
+            map.put("name", name);
+        }
+        if (overwrite != null) {
+            map.put("overwrite", overwrite);
+        }
+        return api.callApi("core", "action", "newSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse loadSession(String apikey, String name) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("name", name);
+        return api.callApi("core", "action", "loadSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse saveSession(String apikey, String name, String overwrite) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("name", name);
+        if (overwrite != null) {
+            map.put("overwrite", overwrite);
+        }
+        return api.callApi("core", "action", "saveSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse snapshotSession(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("core", "action", "snapshotSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse clearExcludedFromProxy(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("core", "action", "clearExcludedFromProxy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse excludeFromProxy(String apikey, String regex) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        return api.callApi("core", "action", "excludeFromProxy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setHomeDirectory(String apikey, String dir) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("dir", dir);
+        return api.callApi("core", "action", "setHomeDirectory", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setMode(String apikey, String mode) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("mode", mode);
+        return api.callApi("core", "action", "setMode", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse generateRootCA(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("core", "action", "generateRootCA", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse sendRequest(String apikey, String request, String followredirects) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("request", request);
+        if (followredirects != null) {
+            map.put("followRedirects", followredirects);
+        }
+        return api.callApi("core", "action", "sendRequest", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse deleteAllAlerts(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("core", "action", "deleteAllAlerts", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse runGarbageCollection(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("core", "action", "runGarbageCollection", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse deleteSiteNode(String apikey, String url, String method, String postdata) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("url", url);
+        if (method != null) {
+            map.put("method", method);
+        }
+        if (postdata != null) {
+            map.put("postData", postdata);
+        }
+        return api.callApi("core", "action", "deleteSiteNode", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionDefaultUserAgent(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("core", "action", "setOptionDefaultUserAgent", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainName(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("core", "action", "setOptionProxyChainName", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainPassword(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("core", "action", "setOptionProxyChainPassword", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainRealm(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("core", "action", "setOptionProxyChainRealm", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainSkipName(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("core", "action", "setOptionProxyChainSkipName", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainUserName(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("core", "action", "setOptionProxyChainUserName", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionHttpStateEnabled(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionHttpStateEnabled", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainPort(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("core", "action", "setOptionProxyChainPort", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProxyChainPrompt(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionProxyChainPrompt", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionSingleCookieRequestHeader(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionSingleCookieRequestHeader", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionTimeoutInSecs(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("core", "action", "setOptionTimeoutInSecs", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionUseProxyChain(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionUseProxyChain", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionUseProxyChainAuth(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionUseProxyChainAuth", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] proxypac(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("core", "other", "proxy.pac", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] rootcert(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("core", "other", "rootcert", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] setproxy(String apikey, String proxy) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("proxy", proxy);
+        return api.callApiOther("core", "other", "setproxy", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] xmlreport(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("core", "other", "xmlreport", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] htmlreport(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("core", "other", "htmlreport", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] messageHar(String apikey, String id) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        return api.callApiOther("core", "other", "messageHar", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] messagesHar(String apikey, String baseurl, String start, String count) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApiOther("core", "other", "messagesHar", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] sendHarRequest(String apikey, String request, String followredirects) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("request", request);
+        if (followredirects != null) {
+            map.put("followRedirects", followredirects);
+        }
+        return api.callApiOther("core", "other", "sendHarRequest", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ForcedUserDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ForcedUserDeprecated.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class ForcedUserDeprecated {
+
+    private final ClientApi api;
+
+    public ForcedUserDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setForcedUser(String apikey, String contextid, String userid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        return api.callApi("forcedUser", "action", "setForcedUser", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setForcedUserModeEnabled(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("boolean", Boolean.toString(bool));
+        return api.callApi("forcedUser", "action", "setForcedUserModeEnabled", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/HttpSessionsDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/HttpSessionsDeprecated.java
@@ -1,0 +1,167 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class HttpSessionsDeprecated {
+
+    private final ClientApi api;
+
+    public HttpSessionsDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse createEmptySession(String apikey, String site, String session) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        if (session != null) {
+            map.put("session", session);
+        }
+        return api.callApi("httpSessions", "action", "createEmptySession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeSession(String apikey, String site, String session) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        map.put("session", session);
+        return api.callApi("httpSessions", "action", "removeSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setActiveSession(String apikey, String site, String session) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        map.put("session", session);
+        return api.callApi("httpSessions", "action", "setActiveSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse unsetActiveSession(String apikey, String site) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        return api.callApi("httpSessions", "action", "unsetActiveSession", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse addSessionToken(String apikey, String site, String sessiontoken) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        map.put("sessionToken", sessiontoken);
+        return api.callApi("httpSessions", "action", "addSessionToken", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeSessionToken(String apikey, String site, String sessiontoken) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        map.put("sessionToken", sessiontoken);
+        return api.callApi("httpSessions", "action", "removeSessionToken", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setSessionTokenValue(String apikey, String site, String session, String sessiontoken, String tokenvalue)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        map.put("session", session);
+        map.put("sessionToken", sessiontoken);
+        map.put("tokenValue", tokenvalue);
+        return api.callApi("httpSessions", "action", "setSessionTokenValue", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse renameSession(String apikey, String site, String oldsessionname, String newsessionname)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("site", site);
+        map.put("oldSessionName", oldsessionname);
+        map.put("newSessionName", newsessionname);
+        return api.callApi("httpSessions", "action", "renameSession", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ImportLogFilesDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ImportLogFilesDeprecated.java
@@ -1,0 +1,123 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class ImportLogFilesDeprecated {
+
+    private final ClientApi api;
+
+    public ImportLogFilesDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse ImportZAPLogFromFile(String apikey, String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("FilePath", filepath);
+        return api.callApi("importLogFiles", "action", "ImportZAPLogFromFile", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse ImportModSecurityLogFromFile(String apikey, String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("FilePath", filepath);
+        return api.callApi("importLogFiles", "action", "ImportModSecurityLogFromFile", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse ImportZAPHttpRequestResponsePair(String apikey, String httprequest, String httpresponse) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("HTTPRequest", httprequest);
+        map.put("HTTPResponse", httpresponse);
+        return api.callApi("importLogFiles", "action", "ImportZAPHttpRequestResponsePair", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse PostModSecurityAuditEvent(String apikey, String auditeventstring) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (auditeventstring != null) {
+            map.put("AuditEventString", auditeventstring);
+        }
+        return api.callApi("importLogFiles", "action", "PostModSecurityAuditEvent", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] OtherPostModSecurityAuditEvent(String apikey, String auditeventstring) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("AuditEventString", auditeventstring);
+        return api.callApiOther("importLogFiles", "other", "OtherPostModSecurityAuditEvent", map);
+    }
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PnhDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PnhDeprecated.java
@@ -1,0 +1,166 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class PnhDeprecated {
+
+    private final ClientApi api;
+
+    public PnhDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse monitor(String apikey, String id, String message) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        map.put("message", message);
+        return api.callApi("pnh", "action", "monitor", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse oracle(String apikey, String id) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        return api.callApi("pnh", "action", "oracle", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse startMonitoring(String apikey, String url) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("url", url);
+        return api.callApi("pnh", "action", "startMonitoring", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse stopMonitoring(String apikey, String id) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        return api.callApi("pnh", "action", "stopMonitoring", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] pnh(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("pnh", "other", "pnh", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] manifest(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("pnh", "other", "manifest", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] service(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("pnh", "other", "service", map);
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] fx_pnhxpi(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApiOther("pnh", "other", "fx_pnh.xpi", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PscanDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PscanDeprecated.java
@@ -1,0 +1,124 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class PscanDeprecated {
+
+    private final ClientApi api;
+
+    public PscanDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setEnabled(String apikey, String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("enabled", enabled);
+        return api.callApi("pscan", "action", "setEnabled", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse enableAllScanners(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("pscan", "action", "enableAllScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse disableAllScanners(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("pscan", "action", "disableAllScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse enableScanners(String apikey, String ids) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("ids", ids);
+        return api.callApi("pscan", "action", "enableScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse disableScanners(String apikey, String ids) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("ids", ids);
+        return api.callApi("pscan", "action", "disableScanners", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setScannerAlertThreshold(String apikey, String id, String alertthreshold) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("id", id);
+        map.put("alertThreshold", alertthreshold);
+        return api.callApi("pscan", "action", "setScannerAlertThreshold", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/RevealDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/RevealDeprecated.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class RevealDeprecated {
+
+    private final ClientApi api;
+
+    public RevealDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setReveal(String apikey, String reveal) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("reveal", reveal);
+        return api.callApi("reveal", "action", "setReveal", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ScriptDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ScriptDeprecated.java
@@ -1,0 +1,123 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class ScriptDeprecated {
+
+    private final ClientApi api;
+
+    public ScriptDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse enable(String apikey, String scriptname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scriptName", scriptname);
+        return api.callApi("script", "action", "enable", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse disable(String apikey, String scriptname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scriptName", scriptname);
+        return api.callApi("script", "action", "disable", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse load(
+            String apikey,
+            String scriptname,
+            String scripttype,
+            String scriptengine,
+            String filename,
+            String scriptdescription) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scriptName", scriptname);
+        map.put("scriptType", scripttype);
+        map.put("scriptEngine", scriptengine);
+        map.put("fileName", filename);
+        if (scriptdescription != null) {
+            map.put("scriptDescription", scriptdescription);
+        }
+        return api.callApi("script", "action", "load", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse remove(String apikey, String scriptname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scriptName", scriptname);
+        return api.callApi("script", "action", "remove", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse runStandAloneScript(String apikey, String scriptname) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scriptName", scriptname);
+        return api.callApi("script", "action", "runStandAloneScript", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SearchDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SearchDeprecated.java
@@ -1,0 +1,136 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class SearchDeprecated {
+
+    private final ClientApi api;
+
+    public SearchDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] harByUrlRegex(String apikey, String regex, String baseurl, String start, String count)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApiOther("search", "other", "harByUrlRegex", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] harByRequestRegex(String apikey, String regex, String baseurl, String start, String count)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApiOther("search", "other", "harByRequestRegex", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] harByResponseRegex(String apikey, String regex, String baseurl, String start, String count)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApiOther("search", "other", "harByResponseRegex", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public byte[] harByHeaderRegex(String apikey, String regex, String baseurl, String start, String count)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApiOther("search", "other", "harByHeaderRegex", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SeleniumDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SeleniumDeprecated.java
@@ -1,0 +1,131 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class SeleniumDeprecated {
+
+    private final ClientApi api;
+
+    public SeleniumDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * Sets the current path to ChromeDriver
+     * <p>
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionChromeDriverPath(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("selenium", "action", "setOptionChromeDriverPath", map);
+    }
+
+    /**
+     * Sets the current path to Firefox binary
+     * <p>
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionFirefoxBinaryPath(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("selenium", "action", "setOptionFirefoxBinaryPath", map);
+    }
+
+    /**
+     * Sets the current path to Firefox driver (geckodriver)
+     * <p>
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionFirefoxDriverPath(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("selenium", "action", "setOptionFirefoxDriverPath", map);
+    }
+
+    /**
+     * Sets the current path to IEDriverServer
+     * <p>
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionIeDriverPath(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("selenium", "action", "setOptionIeDriverPath", map);
+    }
+
+    /**
+     * Sets the current path to PhantomJS binary
+     * <p>
+     * This component is optional and therefore the API will only work if it is installed
+     * 
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionPhantomJsBinaryPath(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("selenium", "action", "setOptionPhantomJsBinaryPath", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SessionManagementDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SessionManagementDeprecated.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class SessionManagementDeprecated {
+
+    private final ClientApi api;
+
+    public SessionManagementDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setSessionManagementMethod(String apikey, String contextid, String methodname, String methodconfigparams)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("methodName", methodname);
+        if (methodconfigparams != null) {
+            map.put("methodConfigParams", methodconfigparams);
+        }
+        return api.callApi("sessionManagement", "action", "setSessionManagementMethod", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SpiderDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SpiderDeprecated.java
@@ -1,0 +1,512 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class SpiderDeprecated {
+
+    private final ClientApi api;
+
+    public SpiderDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse scan(
+            String apikey,
+            String url,
+            String maxchildren,
+            String recurse,
+            String contextname,
+            String subtreeonly) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (url != null) {
+            map.put("url", url);
+        }
+        if (maxchildren != null) {
+            map.put("maxChildren", maxchildren);
+        }
+        if (recurse != null) {
+            map.put("recurse", recurse);
+        }
+        if (contextname != null) {
+            map.put("contextName", contextname);
+        }
+        if (subtreeonly != null) {
+            map.put("subtreeOnly", subtreeonly);
+        }
+        return api.callApi("spider", "action", "scan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse scanAsUser(
+            String apikey,
+            String contextid,
+            String userid,
+            String url,
+            String maxchildren,
+            String recurse,
+            String subtreeonly) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        if (url != null) {
+            map.put("url", url);
+        }
+        if (maxchildren != null) {
+            map.put("maxChildren", maxchildren);
+        }
+        if (recurse != null) {
+            map.put("recurse", recurse);
+        }
+        if (subtreeonly != null) {
+            map.put("subtreeOnly", subtreeonly);
+        }
+        return api.callApi("spider", "action", "scanAsUser", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse pause(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("spider", "action", "pause", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse resume(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("spider", "action", "resume", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse stop(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (scanid != null) {
+            map.put("scanId", scanid);
+        }
+        return api.callApi("spider", "action", "stop", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeScan(String apikey, String scanid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("scanId", scanid);
+        return api.callApi("spider", "action", "removeScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse pauseAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("spider", "action", "pauseAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse resumeAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("spider", "action", "resumeAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse stopAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("spider", "action", "stopAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeAllScans(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("spider", "action", "removeAllScans", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse clearExcludedFromScan(String apikey) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        return api.callApi("spider", "action", "clearExcludedFromScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse excludeFromScan(String apikey, String regex) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("regex", regex);
+        return api.callApi("spider", "action", "excludeFromScan", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionHandleParameters(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("spider", "action", "setOptionHandleParameters", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionScopeString(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("spider", "action", "setOptionScopeString", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionSkipURLString(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("spider", "action", "setOptionSkipURLString", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionUserAgent(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("spider", "action", "setOptionUserAgent", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionHandleODataParametersVisited(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionHandleODataParametersVisited", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxDepth(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("spider", "action", "setOptionMaxDepth", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxDuration(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("spider", "action", "setOptionMaxDuration", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionMaxScansInUI(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("spider", "action", "setOptionMaxScansInUI", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionParseComments(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionParseComments", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionParseGit(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionParseGit", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionParseRobotsTxt(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionParseRobotsTxt", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionParseSVNEntries(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionParseSVNEntries", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionParseSitemapXml(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionParseSitemapXml", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionPostForm(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionPostForm", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionProcessForm(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionProcessForm", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionRequestWaitTime(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("spider", "action", "setOptionRequestWaitTime", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionSendRefererHeader(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionSendRefererHeader", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionShowAdvancedDialog(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("spider", "action", "setOptionShowAdvancedDialog", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionThreadCount(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("spider", "action", "setOptionThreadCount", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/StatsDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/StatsDeprecated.java
@@ -1,0 +1,113 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class StatsDeprecated {
+
+    private final ClientApi api;
+
+    public StatsDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse clearStats(String apikey, String keyprefix) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        if (keyprefix != null) {
+            map.put("keyPrefix", keyprefix);
+        }
+        return api.callApi("stats", "action", "clearStats", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionStatsdHost(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("stats", "action", "setOptionStatsdHost", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionStatsdPrefix(String apikey, String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("String", string);
+        return api.callApi("stats", "action", "setOptionStatsdPrefix", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionInMemoryEnabled(String apikey, boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("stats", "action", "setOptionInMemoryEnabled", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setOptionStatsdPort(String apikey, int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("stats", "action", "setOptionStatsdPort", map);
+    }
+
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/UsersDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/UsersDeprecated.java
@@ -1,0 +1,126 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/**
+ * API implementation with deprecated methods, (re)moved from generated class.
+ */
+@SuppressWarnings("javadoc")
+public class UsersDeprecated {
+
+    private final ClientApi api;
+
+    public UsersDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse newUser(String apikey, String contextid, String name) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("name", name);
+        return api.callApi("users", "action", "newUser", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse removeUser(String apikey, String contextid, String userid) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        return api.callApi("users", "action", "removeUser", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setUserEnabled(String apikey, String contextid, String userid, String enabled)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        map.put("enabled", enabled);
+        return api.callApi("users", "action", "setUserEnabled", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setUserName(String apikey, String contextid, String userid, String name) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        map.put("name", name);
+        return api.callApi("users", "action", "setUserName", map);
+    }
+
+    /**
+     * @deprecated (TODO add version) Use the method without the API key and use one of the {@code ClientApi} constructors that allow to
+     *             set the API key (e.g. {@link ClientApi#ClientApi(String, int, String)}).
+     */
+    @Deprecated
+    public ApiResponse setAuthenticationCredentials(
+            String apikey,
+            String contextid,
+            String userid,
+            String authcredentialsconfigparams) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (apikey != null) {
+            map.put("apikey", apikey);
+        }
+        map.put("contextId", contextid);
+        map.put("userId", userid);
+        if (authcredentialsconfigparams != null) {
+            map.put("authCredentialsConfigParams", authcredentialsconfigparams);
+        }
+        return api.callApi("users", "action", "setAuthenticationCredentials", map);
+    }
+
+}


### PR DESCRIPTION
Change API implementations to not require to set/use the API key in each
API call (e.g. action/other) as that's already done by the ClientApi
class. The old methods (the ones that have the apiKey parameter) are now
in a separate class, to avoid the generated code to replace them, they
are still required for compatibility with older versions. The usage of
the old methods is discouraged (deprecated) and suggested to use the new
ClientApi constructors to set the API key.
Remove usage of the old methods throughout the code (ClientApi,
ClientApiMain, examples, and Ant tasks).