### PR TITLE
Send API key even if there are no parameters

### DIFF
--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -398,6 +398,13 @@ public class ClientApi {
                 }
                 sb.append('&');
             }
+        } else if (apiKey != null && !apiKey.isEmpty()) {
+            // Send the API key even if there are no parameters,
+            // older ZAP versions might need it as (query) parameter.
+            sb.append('?');
+            sb.append(encodeQueryParam(ZAP_API_KEY_PARAM));
+            sb.append('=');
+            sb.append(encodeQueryParam(apiKey));
         }
 
         HttpRequest request = new HttpRequest(new URL(sb.toString()));


### PR DESCRIPTION
Change ClientApi to send the API key as parameter even if there are no
other parameters, older ZAP versions might need it as (query) parameter.
Allows to use non-deprecated methods (that don't have any parameters)
with older/current ZAP version.