### PR TITLE
Regenerate AJAX Spider API (v17)

### DIFF
--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AjaxSpider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AjaxSpider.java
@@ -71,6 +71,13 @@ public class AjaxSpider extends org.zaproxy.clientapi.gen.deprecated.AjaxSpiderD
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
+	public ApiResponse fullResults() throws ClientApiException {
+		return api.callApi("ajaxSpider", "view", "fullResults", null);
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
 	public ApiResponse optionBrowserId() throws ClientApiException {
 		return api.callApi("ajaxSpider", "view", "optionBrowserId", null);
 	}


### PR DESCRIPTION
Regenerate the AJAX Spider API to match the latest version, which allows
to obtain the full results of a scan (requests in and out of scope and
requests with I/O errors).