### PR TITLE
Regenerate core APIs for ZAP version 2.6.0

### DIFF
--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
@@ -41,14 +41,14 @@ public class Acsrf extends org.zaproxy.clientapi.gen.deprecated.AcsrfDeprecated 
 	}
 
 	/**
-	 * Lists the names of all anti CSRF tokens
+	 * Lists the names of all anti-CSRF tokens
 	 */
 	public ApiResponse optionTokensNames() throws ClientApiException {
 		return api.callApi("acsrf", "view", "optionTokensNames", null);
 	}
 
 	/**
-	 * Adds an anti CSRF token with the given name, enabled by default
+	 * Adds an anti-CSRF token with the given name, enabled by default
 	 */
 	public ApiResponse addOptionToken(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
@@ -57,7 +57,7 @@ public class Acsrf extends org.zaproxy.clientapi.gen.deprecated.AcsrfDeprecated 
 	}
 
 	/**
-	 * Removes the anti CSRF token with the given name
+	 * Removes the anti-CSRF token with the given name
 	 */
 	public ApiResponse removeOptionToken(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
@@ -66,7 +66,7 @@ public class Acsrf extends org.zaproxy.clientapi.gen.deprecated.AcsrfDeprecated 
 	}
 
 	/**
-	 * Generate a form for testing lack of anti CSRF tokens - typically invoked via ZAP
+	 * Generate a form for testing lack of anti-CSRF tokens - typically invoked via ZAP
 	 */
 	public byte[] genForm(String hrefid) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
@@ -76,6 +76,9 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		return api.callApi("ascan", "view", "scanPolicyNames", null);
 	}
 
+	/**
+	 * Gets the regexes of URLs excluded from the active scans.
+	 */
 	public ApiResponse excludedFromScan() throws ClientApiException {
 		return api.callApi("ascan", "view", "excludedFromScan", null);
 	}
@@ -106,6 +109,29 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		return api.callApi("ascan", "view", "attackModeQueue", null);
 	}
 
+	/**
+	 * Gets all the parameters that are excluded. For each parameter the following are shown: the name, the URL, and the parameter type.
+	 */
+	public ApiResponse excludedParams() throws ClientApiException {
+		return api.callApi("ascan", "view", "excludedParams", null);
+	}
+
+	/**
+	 * Use view excludedParams instead.
+	 * @deprecated
+	 */
+	@Deprecated
+	public ApiResponse optionExcludedParamList() throws ClientApiException {
+		return api.callApi("ascan", "view", "optionExcludedParamList", null);
+	}
+
+	/**
+	 * Gets all the types of excluded parameters. For each type the following are shown: the ID and the name.
+	 */
+	public ApiResponse excludedParamTypes() throws ClientApiException {
+		return api.callApi("ascan", "view", "excludedParamTypes", null);
+	}
+
 	public ApiResponse optionAttackPolicy() throws ClientApiException {
 		return api.callApi("ascan", "view", "optionAttackPolicy", null);
 	}
@@ -116,10 +142,6 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 
 	public ApiResponse optionDelayInMs() throws ClientApiException {
 		return api.callApi("ascan", "view", "optionDelayInMs", null);
-	}
-
-	public ApiResponse optionExcludedParamList() throws ClientApiException {
-		return api.callApi("ascan", "view", "optionExcludedParamList", null);
 	}
 
 	public ApiResponse optionHandleAntiCSRFTokens() throws ClientApiException {
@@ -136,6 +158,14 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 
 	public ApiResponse optionMaxResultsToList() throws ClientApiException {
 		return api.callApi("ascan", "view", "optionMaxResultsToList", null);
+	}
+
+	public ApiResponse optionMaxRuleDurationInMins() throws ClientApiException {
+		return api.callApi("ascan", "view", "optionMaxRuleDurationInMins", null);
+	}
+
+	public ApiResponse optionMaxScanDurationInMins() throws ClientApiException {
+		return api.callApi("ascan", "view", "optionMaxScanDurationInMins", null);
 	}
 
 	public ApiResponse optionMaxScansInUI() throws ClientApiException {
@@ -158,6 +188,9 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		return api.callApi("ascan", "view", "optionAllowAttackOnStart", null);
 	}
 
+	/**
+	 * Tells whether or not the active scanner should inject the HTTP request header X-ZAP-Scan-ID, with the ID of the scanner that's sending the requests.
+	 */
 	public ApiResponse optionInjectPluginIdInHeader() throws ClientApiException {
 		return api.callApi("ascan", "view", "optionInjectPluginIdInHeader", null);
 	}
@@ -186,8 +219,17 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 	}
 
 	public ApiResponse scan(String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata) throws ClientApiException {
+		return scan(url, recurse, inscopeonly, scanpolicyname, method, postdata, (Integer) null);
+	}
+	
+	/**
+	 * Runs the active scanner against the given URL and/or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
+	 */
+	public ApiResponse scan(String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata, Integer contextid) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		map.put("url", url);
+		if (url != null) {
+			map.put("url", url);
+		}
 		if (recurse != null) {
 			map.put("recurse", recurse);
 		}
@@ -203,6 +245,9 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		if (postdata != null) {
 			map.put("postData", postdata);
 		}
+		if (contextid != null) {
+			map.put("contextId", contextid.toString());
+		}
 		return api.callApi("ascan", "action", "scan", map);
 	}
 
@@ -211,9 +256,15 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 	 */
 	public ApiResponse scanAsUser(String url, String contextid, String userid, String recurse, String scanpolicyname, String method, String postdata) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
-		map.put("url", url);
-		map.put("contextId", contextid);
-		map.put("userId", userid);
+		if (url != null) {
+			map.put("url", url);
+		}
+		if (contextid != null) {
+			map.put("contextId", contextid);
+		}
+		if (userid != null) {
+			map.put("userId", userid);
+		}
 		if (recurse != null) {
 			map.put("recurse", recurse);
 		}
@@ -269,10 +320,16 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		return api.callApi("ascan", "action", "removeAllScans", null);
 	}
 
+	/**
+	 * Clears the regexes of URLs excluded from the active scans.
+	 */
 	public ApiResponse clearExcludedFromScan() throws ClientApiException {
 		return api.callApi("ascan", "action", "clearExcludedFromScan", null);
 	}
 
+	/**
+	 * Adds a regex of URLs that should be excluded from the active scans.
+	 */
 	public ApiResponse excludeFromScan(String regex) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
@@ -363,8 +420,18 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 	}
 
 	public ApiResponse addScanPolicy(String scanpolicyname) throws ClientApiException {
+		return addScanPolicy(scanpolicyname, null, null);
+	}
+
+	public ApiResponse addScanPolicy(String scanpolicyname, String alertthreshold, String attackstrength) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("scanPolicyName", scanpolicyname);
+		if (alertthreshold != null) {
+			map.put("alertThreshold", alertthreshold);
+		}
+		if (attackstrength != null) {
+			map.put("attackStrength", attackstrength);
+		}
 		return api.callApi("ascan", "action", "addScanPolicy", map);
 	}
 
@@ -372,6 +439,60 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		Map<String, String> map = new HashMap<>();
 		map.put("scanPolicyName", scanpolicyname);
 		return api.callApi("ascan", "action", "removeScanPolicy", map);
+	}
+
+	public ApiResponse updateScanPolicy(String scanpolicyname, String alertthreshold, String attackstrength) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("scanPolicyName", scanpolicyname);
+		if (alertthreshold != null) {
+			map.put("alertThreshold", alertthreshold);
+		}
+		if (attackstrength != null) {
+			map.put("attackStrength", attackstrength);
+		}
+		return api.callApi("ascan", "action", "updateScanPolicy", map);
+	}
+
+	/**
+	 * Adds a new parameter excluded from the scan, using the specified name. Optionally sets if the new entry applies to a specific URL (default, all URLs) and sets the ID of the type of the parameter (default, ID of any type). The type IDs can be obtained with the view excludedParamTypes. 
+	 */
+	public ApiResponse addExcludedParam(String name, String type, String url) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("name", name);
+		if (type != null) {
+			map.put("type", type);
+		}
+		if (url != null) {
+			map.put("url", url);
+		}
+		return api.callApi("ascan", "action", "addExcludedParam", map);
+	}
+
+	/**
+	 * Modifies a parameter excluded from the scan. Allows to modify the name, the URL and the type of parameter. The parameter is selected with its index, which can be obtained with the view excludedParams.
+	 */
+	public ApiResponse modifyExcludedParam(String idx, String name, String type, String url) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("idx", idx);
+		if (name != null) {
+			map.put("name", name);
+		}
+		if (type != null) {
+			map.put("type", type);
+		}
+		if (url != null) {
+			map.put("url", url);
+		}
+		return api.callApi("ascan", "action", "modifyExcludedParam", map);
+	}
+
+	/**
+	 * Removes a parameter excluded from the scan, with the given index. The index can be obtained with the view excludedParams.
+	 */
+	public ApiResponse removeExcludedParam(String idx) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("idx", idx);
+		return api.callApi("ascan", "action", "removeExcludedParam", map);
 	}
 
 	public ApiResponse setOptionAttackPolicy(String string) throws ClientApiException {
@@ -410,6 +531,9 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		return api.callApi("ascan", "action", "setOptionHostPerScan", map);
 	}
 
+	/**
+	 * Sets whether or not the active scanner should inject the HTTP request header X-ZAP-Scan-ID, with the ID of the scanner that's sending the requests.
+	 */
 	public ApiResponse setOptionInjectPluginIdInHeader(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
@@ -426,6 +550,18 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("ascan", "action", "setOptionMaxResultsToList", map);
+	}
+
+	public ApiResponse setOptionMaxRuleDurationInMins(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("Integer", Integer.toString(i));
+		return api.callApi("ascan", "action", "setOptionMaxRuleDurationInMins", map);
+	}
+
+	public ApiResponse setOptionMaxScanDurationInMins(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("Integer", Integer.toString(i));
+		return api.callApi("ascan", "action", "setOptionMaxScanDurationInMins", map);
 	}
 
 	public ApiResponse setOptionMaxScansInUI(int i) throws ClientApiException {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
@@ -54,6 +54,34 @@ public class Autoupdate extends org.zaproxy.clientapi.gen.deprecated.AutoupdateD
 		return api.callApi("autoupdate", "view", "isLatestVersion", null);
 	}
 
+	/**
+	 * Return a list of all of the installed add-ons
+	 */
+	public ApiResponse installedAddons() throws ClientApiException {
+		return api.callApi("autoupdate", "view", "installedAddons", null);
+	}
+
+	/**
+	 * Return a list of any add-ons that have been added to the Marketplace since the last check for updates
+	 */
+	public ApiResponse newAddons() throws ClientApiException {
+		return api.callApi("autoupdate", "view", "newAddons", null);
+	}
+
+	/**
+	 * Return a list of any add-ons that have been changed in the Marketplace since the last check for updates
+	 */
+	public ApiResponse updatedAddons() throws ClientApiException {
+		return api.callApi("autoupdate", "view", "updatedAddons", null);
+	}
+
+	/**
+	 * Return a list of all of the add-ons on the ZAP Marketplace (this information is read once and then cached)
+	 */
+	public ApiResponse marketplaceAddons() throws ClientApiException {
+		return api.callApi("autoupdate", "view", "marketplaceAddons", null);
+	}
+
 	public ApiResponse optionAddonDirectories() throws ClientApiException {
 		return api.callApi("autoupdate", "view", "optionAddonDirectories", null);
 	}
@@ -111,6 +139,24 @@ public class Autoupdate extends org.zaproxy.clientapi.gen.deprecated.AutoupdateD
 	 */
 	public ApiResponse downloadLatestRelease() throws ClientApiException {
 		return api.callApi("autoupdate", "action", "downloadLatestRelease", null);
+	}
+
+	/**
+	 * Installs or updates the specified add-on, returning when complete (ie not asynchronously)
+	 */
+	public ApiResponse installAddon(String id) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("id", id);
+		return api.callApi("autoupdate", "action", "installAddon", map);
+	}
+
+	/**
+	 * Uninstalls the specified add-on 
+	 */
+	public ApiResponse uninstallAddon(String id) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("id", id);
+		return api.callApi("autoupdate", "action", "uninstallAddon", map);
 	}
 
 	public ApiResponse setOptionCheckAddonUpdates(boolean bool) throws ClientApiException {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
@@ -40,14 +40,83 @@ public class Break extends org.zaproxy.clientapi.gen.deprecated.BreakDeprecated 
 		this.api = api;
 	}
 
-	public ApiResponse brk(String type, String scope, String state) throws ClientApiException {
+	/**
+	 * Returns True if ZAP will break on both requests and responses
+	 */
+	public ApiResponse isBreakAll() throws ClientApiException {
+		return api.callApi("break", "view", "isBreakAll", null);
+	}
+
+	/**
+	 * Returns True if ZAP will break on requests
+	 */
+	public ApiResponse isBreakRequest() throws ClientApiException {
+		return api.callApi("break", "view", "isBreakRequest", null);
+	}
+
+	/**
+	 * Returns True if ZAP will break on responses
+	 */
+	public ApiResponse isBreakResponse() throws ClientApiException {
+		return api.callApi("break", "view", "isBreakResponse", null);
+	}
+
+	/**
+	 * Returns the HTTP message currently intercepted (if any)
+	 */
+	public ApiResponse httpMessage() throws ClientApiException {
+		return api.callApi("break", "view", "httpMessage", null);
+	}
+
+	/**
+	 * Controls the global break functionality. The type may be one of: http-all, http-request or http-response. The state may be true (for turning break on for the specified type) or false (for turning break off). Scope is not currently used.
+	 */
+	public ApiResponse brk(String type, String state, String scope) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("type", type);
-		map.put("scope", scope);
 		map.put("state", state);
+		if (scope != null) {
+			map.put("scope", scope);
+		}
 		return api.callApi("break", "action", "break", map);
 	}
 
+	/**
+	 * Overwrites the currently intercepted message with the data provided
+	 */
+	public ApiResponse setHttpMessage(String httpheader, String httpbody) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("httpHeader", httpheader);
+		if (httpbody != null) {
+			map.put("httpBody", httpbody);
+		}
+		return api.callApi("break", "action", "setHttpMessage", map);
+	}
+
+	/**
+	 * Submits the currently intercepted message and unsets the global request/response break points
+	 */
+	public ApiResponse cont() throws ClientApiException {
+		return api.callApi("break", "action", "continue", null);
+	}
+
+	/**
+	 * Submits the currently intercepted message, the next request or response will automatically be intercepted
+	 */
+	public ApiResponse step() throws ClientApiException {
+		return api.callApi("break", "action", "step", null);
+	}
+
+	/**
+	 * Drops the currently intercepted message
+	 */
+	public ApiResponse drop() throws ClientApiException {
+		return api.callApi("break", "action", "drop", null);
+	}
+
+	/**
+	 * Adds a custom HTTP breakpont. The string is the string to match. Location may be one of: url, request_header, request_body, response_header or response_body. Match may be: contains or regex. Inverse (match) may be true or false. Lastly, ignorecase (when matching the string) may be true or false.  
+	 */
 	public ApiResponse addHttpBreakpoint(String string, String location, String match, String inverse, String ignorecase) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("string", string);
@@ -58,6 +127,9 @@ public class Break extends org.zaproxy.clientapi.gen.deprecated.BreakDeprecated 
 		return api.callApi("break", "action", "addHttpBreakpoint", map);
 	}
 
+	/**
+	 * Removes the specified break point
+	 */
 	public ApiResponse removeHttpBreakpoint(String string, String location, String match, String inverse, String ignorecase) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("string", string);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
@@ -160,8 +160,56 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "view", "homeDirectory", null);
 	}
 
+	/**
+	 * Gets the location of the current session file
+	 */
+	public ApiResponse sessionLocation() throws ClientApiException {
+		return api.callApi("core", "view", "sessionLocation", null);
+	}
+
+	/**
+	 * Gets all the domains that are excluded from the outgoing proxy. For each domain the following are shown: the index, the value (domain), if enabled, and if specified as a regex.
+	 */
+	public ApiResponse proxyChainExcludedDomains() throws ClientApiException {
+		return api.callApi("core", "view", "proxyChainExcludedDomains", null);
+	}
+
+	/**
+	 * Use view proxyChainExcludedDomains instead.
+	 * @deprecated
+	 */
+	@Deprecated
+	public ApiResponse optionProxyChainSkipName() throws ClientApiException {
+		return api.callApi("core", "view", "optionProxyChainSkipName", null);
+	}
+
+	/**
+	 * Use view proxyChainExcludedDomains instead.
+	 * @deprecated
+	 */
+	@Deprecated
+	public ApiResponse optionProxyExcludedDomains() throws ClientApiException {
+		return api.callApi("core", "view", "optionProxyExcludedDomains", null);
+	}
+
+	/**
+	 * Use view proxyChainExcludedDomains instead.
+	 * @deprecated
+	 */
+	@Deprecated
+	public ApiResponse optionProxyExcludedDomainsEnabled() throws ClientApiException {
+		return api.callApi("core", "view", "optionProxyExcludedDomainsEnabled", null);
+	}
+
 	public ApiResponse optionDefaultUserAgent() throws ClientApiException {
 		return api.callApi("core", "view", "optionDefaultUserAgent", null);
+	}
+
+	/**
+	 * Gets the TTL (in seconds) of successful DNS queries.
+	 */
+	public ApiResponse optionDnsTtlSuccessfulQueries() throws ClientApiException {
+		return api.callApi("core", "view", "optionDnsTtlSuccessfulQueries", null);
 	}
 
 	public ApiResponse optionHttpState() throws ClientApiException {
@@ -184,20 +232,8 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "view", "optionProxyChainRealm", null);
 	}
 
-	public ApiResponse optionProxyChainSkipName() throws ClientApiException {
-		return api.callApi("core", "view", "optionProxyChainSkipName", null);
-	}
-
 	public ApiResponse optionProxyChainUserName() throws ClientApiException {
 		return api.callApi("core", "view", "optionProxyChainUserName", null);
-	}
-
-	public ApiResponse optionProxyExcludedDomains() throws ClientApiException {
-		return api.callApi("core", "view", "optionProxyExcludedDomains", null);
-	}
-
-	public ApiResponse optionProxyExcludedDomainsEnabled() throws ClientApiException {
-		return api.callApi("core", "view", "optionProxyExcludedDomainsEnabled", null);
 	}
 
 	public ApiResponse optionTimeoutInSecs() throws ClientApiException {
@@ -282,10 +318,16 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "action", "snapshotSession", null);
 	}
 
+	/**
+	 * Clears the regexes of URLs excluded from the proxy.
+	 */
 	public ApiResponse clearExcludedFromProxy() throws ClientApiException {
 		return api.callApi("core", "action", "clearExcludedFromProxy", null);
 	}
 
+	/**
+	 * Adds a regex of URLs that should be excluded from the proxy.
+	 */
 	public ApiResponse excludeFromProxy(String regex) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
@@ -307,12 +349,15 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "action", "setMode", map);
 	}
 
+	/**
+	 * Generates a new Root CA certificate for the Local Proxy.
+	 */
 	public ApiResponse generateRootCA() throws ClientApiException {
 		return api.callApi("core", "action", "generateRootCA", null);
 	}
 
 	/**
-	 * Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any.
+	 * Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
 	 */
 	public ApiResponse sendRequest(String request, String followredirects) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
@@ -323,6 +368,9 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "action", "sendRequest", map);
 	}
 
+	/**
+	 * Deletes all alerts of the current session.
+	 */
 	public ApiResponse deleteAllAlerts() throws ClientApiException {
 		return api.callApi("core", "action", "deleteAllAlerts", null);
 	}
@@ -344,6 +392,62 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 			map.put("postData", postdata);
 		}
 		return api.callApi("core", "action", "deleteSiteNode", map);
+	}
+
+	/**
+	 * Adds a domain to be excluded from the outgoing proxy, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
+	 */
+	public ApiResponse addProxyChainExcludedDomain(String value, String isregex, String isenabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("value", value);
+		if (isregex != null) {
+			map.put("isRegex", isregex);
+		}
+		if (isenabled != null) {
+			map.put("isEnabled", isenabled);
+		}
+		return api.callApi("core", "action", "addProxyChainExcludedDomain", map);
+	}
+
+	/**
+	 * Modifies a domain excluded from the outgoing proxy. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view proxyChainExcludedDomains.
+	 */
+	public ApiResponse modifyProxyChainExcludedDomain(String idx, String value, String isregex, String isenabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("idx", idx);
+		if (value != null) {
+			map.put("value", value);
+		}
+		if (isregex != null) {
+			map.put("isRegex", isregex);
+		}
+		if (isenabled != null) {
+			map.put("isEnabled", isenabled);
+		}
+		return api.callApi("core", "action", "modifyProxyChainExcludedDomain", map);
+	}
+
+	/**
+	 * Removes a domain excluded from the outgoing proxy, with the given index. The index can be obtained with the view proxyChainExcludedDomains.
+	 */
+	public ApiResponse removeProxyChainExcludedDomain(String idx) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("idx", idx);
+		return api.callApi("core", "action", "removeProxyChainExcludedDomain", map);
+	}
+
+	/**
+	 * Enables all domains excluded from the outgoing proxy.
+	 */
+	public ApiResponse enableAllProxyChainExcludedDomains() throws ClientApiException {
+		return api.callApi("core", "action", "enableAllProxyChainExcludedDomains", null);
+	}
+
+	/**
+	 * Disables all domains excluded from the outgoing proxy.
+	 */
+	public ApiResponse disableAllProxyChainExcludedDomains() throws ClientApiException {
+		return api.callApi("core", "action", "disableAllProxyChainExcludedDomains", null);
 	}
 
 	public ApiResponse setOptionDefaultUserAgent(String string) throws ClientApiException {
@@ -370,6 +474,11 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "action", "setOptionProxyChainRealm", map);
 	}
 
+	/**
+	 * Use actions [add|modify|remove]ProxyChainExcludedDomain instead.
+	 * @deprecated
+	 */
+	@Deprecated
 	public ApiResponse setOptionProxyChainSkipName(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
@@ -380,6 +489,15 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
 		return api.callApi("core", "action", "setOptionProxyChainUserName", map);
+	}
+
+	/**
+	 * Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
+	 */
+	public ApiResponse setOptionDnsTtlSuccessfulQueries(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("Integer", Integer.toString(i));
+		return api.callApi("core", "action", "setOptionDnsTtlSuccessfulQueries", map);
 	}
 
 	public ApiResponse setOptionHttpStateEnabled(boolean bool) throws ClientApiException {
@@ -428,6 +546,9 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApiOther("core", "other", "proxy.pac", null);
 	}
 
+	/**
+	 * Gets the Root CA certificate of the Local Proxy.
+	 */
 	public byte[] rootcert() throws ClientApiException {
 		return api.callApiOther("core", "other", "rootcert", null);
 	}
@@ -450,6 +571,13 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	 */
 	public byte[] htmlreport() throws ClientApiException {
 		return api.callApiOther("core", "other", "htmlreport", null);
+	}
+
+	/**
+	 * Generates a report in Markdown format
+	 */
+	public byte[] mdreport() throws ClientApiException {
+		return api.callApiOther("core", "other", "mdreport", null);
 	}
 
 	/**
@@ -479,7 +607,7 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any.
+	 * Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
 	 */
 	public byte[] sendHarRequest(String request, String followredirects) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
@@ -41,7 +41,14 @@ public class HttpSessions extends org.zaproxy.clientapi.gen.deprecated.HttpSessi
 	}
 
 	/**
-	 * Gets the sessions of the given site. Optionally returning just the session with the given name.
+	 * Gets all of the sites that have sessions.
+	 */
+	public ApiResponse sites() throws ClientApiException {
+		return api.callApi("httpSessions", "view", "sites", null);
+	}
+
+	/**
+	 * Gets the sessions for the given site. Optionally returning just the session with the given name.
 	 */
 	public ApiResponse sessions(String site, String session) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
@@ -41,6 +41,13 @@ public class Pscan extends org.zaproxy.clientapi.gen.deprecated.PscanDeprecated 
 	}
 
 	/**
+	 * Tells whether or not the passive scan should be performed only on messages that are in scope.
+	 */
+	public ApiResponse scanOnlyInScope() throws ClientApiException {
+		return api.callApi("pscan", "view", "scanOnlyInScope", null);
+	}
+
+	/**
 	 * The number of records the passive scanner still has to scan
 	 */
 	public ApiResponse recordsToScan() throws ClientApiException {
@@ -55,12 +62,21 @@ public class Pscan extends org.zaproxy.clientapi.gen.deprecated.PscanDeprecated 
 	}
 
 	/**
-	 * Sets whether or not the passive scanning is enabled
+	 * Sets whether or not the passive scanning is enabled (Note: the enabled state is not persisted).
 	 */
 	public ApiResponse setEnabled(String enabled) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("enabled", enabled);
 		return api.callApi("pscan", "action", "setEnabled", map);
+	}
+
+	/**
+	 * Sets whether or not the passive scan should be performed only on messages that are in scope.
+	 */
+	public ApiResponse setScanOnlyInScope(String onlyinscope) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("onlyInScope", onlyinscope);
+		return api.callApi("pscan", "action", "setScanOnlyInScope", map);
 	}
 
 	/**

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
@@ -66,20 +66,54 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "view", "scans", null);
 	}
 
+	/**
+	 * Gets the regexes of URLs excluded from the spider scans.
+	 */
 	public ApiResponse excludedFromScan() throws ClientApiException {
 		return api.callApi("spider", "view", "excludedFromScan", null);
 	}
 
+	/**
+	 * Returns a list of unique URLs from the history table based on HTTP messages added by the Spider.
+	 */
+	public ApiResponse allUrls() throws ClientApiException {
+		return api.callApi("spider", "view", "allUrls", null);
+	}
+
+	/**
+	 * Gets all the domains that are always in scope. For each domain the following are shown: the index, the value (domain), if enabled, and if specified as a regex.
+	 */
+	public ApiResponse domainsAlwaysInScope() throws ClientApiException {
+		return api.callApi("spider", "view", "domainsAlwaysInScope", null);
+	}
+
+	/**
+	 * Use view domainsAlwaysInScope instead.
+	 * @deprecated
+	 */
+	@Deprecated
 	public ApiResponse optionDomainsAlwaysInScope() throws ClientApiException {
 		return api.callApi("spider", "view", "optionDomainsAlwaysInScope", null);
 	}
 
+	/**
+	 * Use view domainsAlwaysInScope instead.
+	 * @deprecated
+	 */
+	@Deprecated
 	public ApiResponse optionDomainsAlwaysInScopeEnabled() throws ClientApiException {
 		return api.callApi("spider", "view", "optionDomainsAlwaysInScopeEnabled", null);
 	}
 
 	public ApiResponse optionHandleParameters() throws ClientApiException {
 		return api.callApi("spider", "view", "optionHandleParameters", null);
+	}
+
+	/**
+	 * Gets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
+	 */
+	public ApiResponse optionMaxChildren() throws ClientApiException {
+		return api.callApi("spider", "view", "optionMaxChildren", null);
 	}
 
 	public ApiResponse optionMaxDepth() throws ClientApiException {
@@ -98,10 +132,12 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "view", "optionRequestWaitTime", null);
 	}
 
+	@Deprecated
 	public ApiResponse optionScope() throws ClientApiException {
 		return api.callApi("spider", "view", "optionScope", null);
 	}
 
+	@Deprecated
 	public ApiResponse optionScopeText() throws ClientApiException {
 		return api.callApi("spider", "view", "optionScopeText", null);
 	}
@@ -151,7 +187,7 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 	}
 
 	/**
-	 * Sets whether or not the 'Referer' header should be sent while spidering
+	 * Gets whether or not the 'Referer' header should be sent while spidering.
 	 */
 	public ApiResponse optionSendRefererHeader() throws ClientApiException {
 		return api.callApi("spider", "view", "optionSendRefererHeader", null);
@@ -248,14 +284,76 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "action", "removeAllScans", null);
 	}
 
+	/**
+	 * Clears the regexes of URLs excluded from the spider scans.
+	 */
 	public ApiResponse clearExcludedFromScan() throws ClientApiException {
 		return api.callApi("spider", "action", "clearExcludedFromScan", null);
 	}
 
+	/**
+	 * Adds a regex of URLs that should be excluded from the spider scans.
+	 */
 	public ApiResponse excludeFromScan(String regex) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("regex", regex);
 		return api.callApi("spider", "action", "excludeFromScan", map);
+	}
+
+	/**
+	 * Adds a new domain that's always in scope, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
+	 */
+	public ApiResponse addDomainAlwaysInScope(String value, String isregex, String isenabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("value", value);
+		if (isregex != null) {
+			map.put("isRegex", isregex);
+		}
+		if (isenabled != null) {
+			map.put("isEnabled", isenabled);
+		}
+		return api.callApi("spider", "action", "addDomainAlwaysInScope", map);
+	}
+
+	/**
+	 * Modifies a domain that's always in scope. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view domainsAlwaysInScope.
+	 */
+	public ApiResponse modifyDomainAlwaysInScope(String idx, String value, String isregex, String isenabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("idx", idx);
+		if (value != null) {
+			map.put("value", value);
+		}
+		if (isregex != null) {
+			map.put("isRegex", isregex);
+		}
+		if (isenabled != null) {
+			map.put("isEnabled", isenabled);
+		}
+		return api.callApi("spider", "action", "modifyDomainAlwaysInScope", map);
+	}
+
+	/**
+	 * Removes a domain that's always in scope, with the given index. The index can be obtained with the view domainsAlwaysInScope.
+	 */
+	public ApiResponse removeDomainAlwaysInScope(String idx) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("idx", idx);
+		return api.callApi("spider", "action", "removeDomainAlwaysInScope", map);
+	}
+
+	/**
+	 * Enables all domains that are always in scope.
+	 */
+	public ApiResponse enableAllDomainsAlwaysInScope() throws ClientApiException {
+		return api.callApi("spider", "action", "enableAllDomainsAlwaysInScope", null);
+	}
+
+	/**
+	 * Disables all domains that are always in scope.
+	 */
+	public ApiResponse disableAllDomainsAlwaysInScope() throws ClientApiException {
+		return api.callApi("spider", "action", "disableAllDomainsAlwaysInScope", null);
 	}
 
 	public ApiResponse setOptionHandleParameters(String string) throws ClientApiException {
@@ -264,6 +362,11 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "action", "setOptionHandleParameters", map);
 	}
 
+	/**
+	 * Use actions [add|modify|remove]DomainAlwaysInScope instead.
+	 * @deprecated
+	 */
+	@Deprecated
 	public ApiResponse setOptionScopeString(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
@@ -286,6 +389,15 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
 		return api.callApi("spider", "action", "setOptionHandleODataParametersVisited", map);
+	}
+
+	/**
+	 * Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
+	 */
+	public ApiResponse setOptionMaxChildren(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("Integer", Integer.toString(i));
+		return api.callApi("spider", "action", "setOptionMaxChildren", map);
 	}
 
 	public ApiResponse setOptionMaxDepth(int i) throws ClientApiException {
@@ -354,6 +466,9 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "action", "setOptionRequestWaitTime", map);
 	}
 
+	/**
+	 * Sets whether or not the 'Referer' header should be sent while spidering.
+	 */
 	public ApiResponse setOptionSendRefererHeader(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));


### PR DESCRIPTION
Regenerate core APIs for ZAP version 2.6.0 (some tweaks were done to
keep the API client binary compatible with previous versions).