### PR TITLE
Update Ant tasks to wait for the scans to finish

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Summary of the changes done in each version.
  - Import files containing URLs ("importurls").
  - OpenAPI Support ("openapi").
 
+### Ant Tasks
+
+ - Update scan tasks to wait for the corresponding scan to finish.
+
 ## 1.2.0 (2017-03-29)
 
 ### Updated APIs

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AbstractActiveScanTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AbstractActiveScanTask.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.ant;
+
+import org.apache.tools.ant.BuildException;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+public abstract class AbstractActiveScanTask extends ZapTask {
+
+	private String url;
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	@Override
+	public void execute() throws BuildException {
+		try {
+			waitForActiveScan(extractValue(startScan()));
+		} catch (Exception e) {
+			throw new BuildException(e);
+		}
+	}
+
+	protected abstract ApiResponse startScan() throws ClientApiException;
+
+	private void waitForActiveScan(String scanId) throws ClientApiException, InterruptedException {
+		int progress;
+		do {
+			progress = Integer.parseInt(extractValue(getClientApi().ascan.status(scanId)));
+			Thread.sleep(1000);
+		} while (progress < 100);
+	}
+}

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
@@ -19,27 +19,14 @@
  */
 package org.zaproxy.clientapi.ant;
 
-import org.apache.tools.ant.BuildException;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApiException;
 
-public class ActiveScanSubtreeTask extends ZapTask {
-	
-	private String url;
-	
+public class ActiveScanSubtreeTask extends AbstractActiveScanTask {
+
 	@Override
-	public void execute() throws BuildException {
-		try {
-			this.getClientApi().ascan.scan(url, "true", "false", "", "", "");
-			
-		} catch (Exception e) {
-			throw new BuildException(e);
-		}
+	protected ApiResponse startScan() throws ClientApiException {
+		return this.getClientApi().ascan.scan(getUrl(), "true", "false", "", "", "");
 	}
 
-	public String getUrl() {
-		return url;
-	}
-
-	public void setUrl(String url) {
-		this.url = url;
-	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanUrlTask.java
@@ -19,27 +19,13 @@
  */
 package org.zaproxy.clientapi.ant;
 
-import org.apache.tools.ant.BuildException;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApiException;
 
-public class ActiveScanUrlTask extends ZapTask {
-	
-	private String url;
+public class ActiveScanUrlTask extends AbstractActiveScanTask {
 
 	@Override
-	public void execute() throws BuildException {
-		try {
-			this.getClientApi().ascan.scan(url, "false", "false", "", "", "");
-			
-		} catch (Exception e) {
-			throw new BuildException(e);
-		}
-	}
-
-	public String getUrl() {
-		return url;
-	}
-
-	public void setUrl(String url) {
-		this.url = url;
+	protected ApiResponse startScan() throws ClientApiException {
+		return this.getClientApi().ascan.scan(getUrl(), "false", "false", "", "", "");
 	}
 }

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
@@ -28,7 +28,13 @@ public class SpiderUrlTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().spider.scan(url, "", "", null, null);
+			String scanId = extractValue(this.getClientApi().spider.scan(url, "", "", null, null));
+
+			int progress;
+			do {
+				progress = Integer.parseInt(extractValue(this.getClientApi().spider.status(scanId)));
+				Thread.sleep(1000);
+			} while (progress < 100);
 			
 		} catch (Exception e) {
 			throw new BuildException(e);

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ZapTask.java
@@ -20,6 +20,8 @@
 package org.zaproxy.clientapi.ant;
 
 import org.apache.tools.ant.Task;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ApiResponseElement;
 import org.zaproxy.clientapi.core.ClientApi;
 
 public abstract class ZapTask extends Task {
@@ -59,5 +61,12 @@ public abstract class ZapTask extends Task {
 
 	public void setApikey(String apikey) {
 		this.apikey = apikey;
+	}
+
+	protected String extractValue(ApiResponse element) {
+		if (element instanceof ApiResponseElement) {
+			return ((ApiResponseElement) element).getValue();
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Change ActiveScanSubtreeTask, ActiveScanUrlTask, and SpiderUrlTask to
wait for the scans to finish before returning.
Refactor the active scan tasks to reduce code duplication (they differ
only on the parameters used to start the scan).
Update the tests to assert the new behaviour (i.e. scan tasks check the
status of the scans).