### PR TITLE
Add an Ant task to create ZAP reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,22 @@ Summary of the changes done in each version.
 
 ## 1.4.0-SNAPSHOT (Not yet released)
 
+### Ant Tasks
+
+ - New task to create ZAP reports:
+   ```XML
+   <!-- Defined the task: -->
+   <taskdef name="reportTask" classname="org.zaproxy.clientapi.ant.ReportTask" />
+   <!-- Call the task: -->
+   <reportTask zapAddress="localhost" zapPort="8080" apikey="API-KEY"
+       type="html" file="report.html" overwrite="true" />
+       <!--
+           type - the type/format of the report (e.g. HTML, XML, MD), defaults to HTML.
+           file - where the report should be created (can be an absolute path, if relative it is resolved against the build directory).
+           overwrite - if the file should be overwritten.
+       -->
+   ```
+
 ## 1.3.0 (2017-06-23)
 
 ### New APIs

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ReportTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ReportTask.java
@@ -1,0 +1,129 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.ant;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.tools.ant.BuildException;
+
+public class ReportTask extends ZapTask {
+
+	private static final String HTML_REPORT_TYPE = "html";
+	private static final String MD_REPORT_TYPE = "md";
+	private static final String XML_REPORT_TYPE = "xml";
+	private static final String DEFAULT_REPORT_TYPE = HTML_REPORT_TYPE;
+
+	private static final List<String> SUPPORTED_REPORT_TYPES = Arrays.asList(HTML_REPORT_TYPE, MD_REPORT_TYPE, XML_REPORT_TYPE);
+
+	private String type = DEFAULT_REPORT_TYPE;
+	private File file;
+	private boolean overwrite;
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public void setFile(String file) {
+		this.file = new File(file);
+		if (!this.file.isAbsolute()) {
+			this.file = new File(getProject().getBaseDir(), file);
+		}
+	}
+
+	public void setOverwrite(boolean overwrite) {
+		this.overwrite = overwrite;
+	}
+
+	@Override
+	public void execute() throws BuildException {
+		validateTaskAttributes();
+
+		byte[] reportContents;
+		try {
+			switch (type.toLowerCase()) {
+			case MD_REPORT_TYPE:
+				reportContents = this.getClientApi().core.mdreport();
+				break;
+			case XML_REPORT_TYPE:
+				reportContents = this.getClientApi().core.xmlreport();
+				break;
+			case HTML_REPORT_TYPE:
+			default:
+				reportContents = this.getClientApi().core.htmlreport();
+				break;
+			}
+		} catch (Exception e) {
+			throw new BuildException("Failed to obtain the report from ZAP: " + e.getMessage(), e);
+		}
+
+		try (OutputStream os = Files.newOutputStream(file.toPath())) {
+			os.write(reportContents);
+		} catch (IOException e) {
+			throw new BuildException("Failed to save the report: " + e.getMessage(), e);
+		}
+
+	}
+
+	private void validateTaskAttributes() {
+		if (type == null || type.isEmpty()) {
+			type = DEFAULT_REPORT_TYPE;
+		} else {
+			type = type.toLowerCase(Locale.ROOT);
+			if (!SUPPORTED_REPORT_TYPES.contains(type)) {
+				throw new BuildException("Unknown report type [" + type + "], supported types: " + SUPPORTED_REPORT_TYPES);
+			}
+		}
+
+		if (file == null) {
+			throw new BuildException("The 'file' attribute must be provided.");
+		}
+
+		if (file.isFile()) {
+			if (!file.canWrite()) {
+				throw new BuildException("The provided file is not writable: " + file.getAbsolutePath());
+			}
+
+			if (!overwrite) {
+				throw new BuildException(
+						"The file already exists but 'overwrite' attribute is not set to 'true': " + file.getAbsolutePath());
+			}
+		} else if (!file.exists()) {
+			File dir = file.getParentFile();
+			if (dir == null) {
+				throw new BuildException(
+						"Unable to determine parent directory of the file provided: " + file.getAbsolutePath());
+			}
+
+			dir.mkdirs();
+			if (!dir.canWrite()) {
+				throw new BuildException("The provided directory does not exist or is not writable: " + dir.getAbsolutePath());
+			}
+		} else {
+			throw new BuildException("The 'file' attribute does not specify a file: " + file.getAbsolutePath());
+		}
+	}
+
+}

--- a/subprojects/zap-clientapi-ant/src/test/resources/org/zaproxy/clientapi/ant/build.xml
+++ b/subprojects/zap-clientapi-ant/src/test/resources/org/zaproxy/clientapi/ant/build.xml
@@ -10,6 +10,7 @@
 	<taskdef name="saveSessionTask" classname="org.zaproxy.clientapi.ant.SaveSessionTask" />
 	<taskdef name="spiderUrlTask" classname="org.zaproxy.clientapi.ant.SpiderUrlTask" />
 	<taskdef name="stopZapTask" classname="org.zaproxy.clientapi.ant.StopZapTask" />
+	<taskdef name="reportTask" classname="org.zaproxy.clientapi.ant.ReportTask" />
 
 	<target name="accessUrl">
 		<accessUrlTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" url="${zap.targetUrl}" />
@@ -56,6 +57,11 @@
 
 	<target name="stopZap">
 		<stopZapTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}" />
+	</target>
+
+	<target name="report">
+		<reportTask zapAddress="${zap.addr}" zapPort="${zap.port}" debug="true" apikey="${zap.key}"
+			type="${zap.report.type}" file="${zap.report.path}" overwrite="${zap.report.overwrite}" />
 	</target>
 
 </project>


### PR DESCRIPTION
Add a new task, ReportTask, that allows to create the ZAP report.
Add test to check that the new Ant task is called.

Fix zaproxy/zaproxy#3712 - Allow to create reports with Ant tasks