### PR TITLE
Regenerate core APIs for ZAP version 2.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Summary of the changes done in each version.
 
 ## 1.5.0-SNAPSHOT (Not yet released)
 
+### Updated APIs
+
+ - Core APIs updated for ZAP version 2.7.0.
+
 ## 1.4.0 (2017-07-13)
 
 ### Ant Tasks

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,12 +56,18 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		return api.callApi("ascan", "view", "scanProgress", map);
 	}
 
+	/**
+	 * Gets the IDs of the messages sent during the scan with the given ID. A message can be obtained with 'message' core view.
+	 */
 	public ApiResponse messagesIds(String scanid) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
 		return api.callApi("ascan", "view", "messagesIds", map);
 	}
 
+	/**
+	 * Gets the IDs of the alerts raised during the scan with the given ID. An alert can be obtained with 'alert' core view.
+	 */
 	public ApiResponse alertsIds(String scanid) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("scanId", scanid);
@@ -454,6 +460,15 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 	}
 
 	/**
+	 * Imports a Scan Policy using the given file system path.
+	 */
+	public ApiResponse importScanPolicy(String path) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("path", path);
+		return api.callApi("ascan", "action", "importScanPolicy", map);
+	}
+
+	/**
 	 * Adds a new parameter excluded from the scan, using the specified name. Optionally sets if the new entry applies to a specific URL (default, all URLs) and sets the ID of the type of the parameter (default, ID of any type). The type IDs can be obtained with the view excludedParamTypes. 
 	 */
 	public ApiResponse addExcludedParam(String name, String type, String url) throws ClientApiException {
@@ -493,6 +508,16 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
 		Map<String, String> map = new HashMap<>();
 		map.put("idx", idx);
 		return api.callApi("ascan", "action", "removeExcludedParam", map);
+	}
+
+	/**
+	 * Skips the scanner using the given IDs of the scan and the scanner.
+	 */
+	public ApiResponse skipScanner(String scanid, String scannerid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("scanId", scanid);
+		map.put("scannerId", scannerid);
+		return api.callApi("ascan", "action", "skipScanner", map);
 	}
 
 	public ApiResponse setOptionAttackPolicy(String string) throws ClientApiException {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authentication.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authentication.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authorization.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authorization.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Context.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Context.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,9 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Gets the alerts raised by ZAP, optionally filtering by URL and paginating with 'start' position and 'count' of alerts
+	 * Gets the alerts raised by ZAP, optionally filtering by URL or riskId, and paginating with 'start' position and 'count' of alerts
 	 */
-	public ApiResponse alerts(String baseurl, String start, String count) throws ClientApiException {
+	public ApiResponse alerts(String baseurl, String start, String count, String riskid) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
@@ -63,16 +63,33 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		if (count != null) {
 			map.put("count", count);
 		}
+		if (riskid != null) {
+			map.put("riskId", riskid);
+		}
 		return api.callApi("core", "view", "alerts", map);
 	}
 
 	/**
-	 * Gets the number of alerts, optionally filtering by URL
+	 * Gets number of alerts grouped by each risk level, optionally filtering by URL
 	 */
-	public ApiResponse numberOfAlerts(String baseurl) throws ClientApiException {
+	public ApiResponse alertsSummary(String baseurl) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		if (baseurl != null) {
 			map.put("baseurl", baseurl);
+		}
+		return api.callApi("core", "view", "alertsSummary", map);
+	}
+
+	/**
+	 * Gets the number of alerts, optionally filtering by URL or riskId
+	 */
+	public ApiResponse numberOfAlerts(String baseurl, String riskid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		if (baseurl != null) {
+			map.put("baseurl", baseurl);
+		}
+		if (riskid != null) {
+			map.put("riskId", riskid);
 		}
 		return api.callApi("core", "view", "numberOfAlerts", map);
 	}
@@ -92,14 +109,18 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Gets the URLs accessed through/by ZAP
+	 * Gets the URLs accessed through/by ZAP, optionally filtering by (base) URL.
 	 */
-	public ApiResponse urls() throws ClientApiException {
-		return api.callApi("core", "view", "urls", null);
+	public ApiResponse urls(String baseurl) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		if (baseurl != null) {
+			map.put("baseurl", baseurl);
+		}
+		return api.callApi("core", "view", "urls", map);
 	}
 
 	/**
-	 * Gets the HTTP message with the given ID. Returns the ID, request/response headers and bodies, cookies and note.
+	 * Gets the HTTP message with the given ID. Returns the ID, request/response headers and bodies, cookies, note, type, RTT, and timestamp.
 	 */
 	public ApiResponse message(String id) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
@@ -122,6 +143,15 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 			map.put("count", count);
 		}
 		return api.callApi("core", "view", "messages", map);
+	}
+
+	/**
+	 * Gets the HTTP messages with the given IDs.
+	 */
+	public ApiResponse messagesById(String ids) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("ids", ids);
+		return api.callApi("core", "view", "messagesById", map);
 	}
 
 	/**
@@ -150,7 +180,7 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Gets the regular expressions, applied to URLs, to exclude from the Proxy
+	 * Gets the regular expressions, applied to URLs, to exclude from the local proxies.
 	 */
 	public ApiResponse excludedFromProxy() throws ClientApiException {
 		return api.callApi("core", "view", "excludedFromProxy", null);
@@ -201,6 +231,37 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "view", "optionProxyExcludedDomainsEnabled", null);
 	}
 
+	/**
+	 * Gets the path to ZAP's home directory.
+	 */
+	public ApiResponse zapHomePath() throws ClientApiException {
+		return api.callApi("core", "view", "zapHomePath", null);
+	}
+
+	/**
+	 * Gets the maximum number of alert instances to include in a report.
+	 */
+	public ApiResponse optionMaximumAlertInstances() throws ClientApiException {
+		return api.callApi("core", "view", "optionMaximumAlertInstances", null);
+	}
+
+	/**
+	 * Gets whether or not related alerts will be merged in any reports generated.
+	 */
+	public ApiResponse optionMergeRelatedAlerts() throws ClientApiException {
+		return api.callApi("core", "view", "optionMergeRelatedAlerts", null);
+	}
+
+	/**
+	 * Gets the path to the file with alert overrides.
+	 */
+	public ApiResponse optionAlertOverridesFilePath() throws ClientApiException {
+		return api.callApi("core", "view", "optionAlertOverridesFilePath", null);
+	}
+
+	/**
+	 * Gets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
+	 */
 	public ApiResponse optionDefaultUserAgent() throws ClientApiException {
 		return api.callApi("core", "view", "optionDefaultUserAgent", null);
 	}
@@ -319,14 +380,14 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Clears the regexes of URLs excluded from the proxy.
+	 * Clears the regexes of URLs excluded from the local proxies.
 	 */
 	public ApiResponse clearExcludedFromProxy() throws ClientApiException {
 		return api.callApi("core", "action", "clearExcludedFromProxy", null);
 	}
 
 	/**
-	 * Adds a regex of URLs that should be excluded from the proxy.
+	 * Adds a regex of URLs that should be excluded from the local proxies.
 	 */
 	public ApiResponse excludeFromProxy(String regex) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
@@ -350,7 +411,7 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Generates a new Root CA certificate for the Local Proxy.
+	 * Generates a new Root CA certificate for the local proxies.
 	 */
 	public ApiResponse generateRootCA() throws ClientApiException {
 		return api.callApi("core", "action", "generateRootCA", null);
@@ -373,6 +434,15 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	 */
 	public ApiResponse deleteAllAlerts() throws ClientApiException {
 		return api.callApi("core", "action", "deleteAllAlerts", null);
+	}
+
+	/**
+	 * Deletes the alert with the given ID. 
+	 */
+	public ApiResponse deleteAlert(String id) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("id", id);
+		return api.callApi("core", "action", "deleteAlert", map);
 	}
 
 	public ApiResponse runGarbageCollection() throws ClientApiException {
@@ -450,6 +520,38 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "action", "disableAllProxyChainExcludedDomains", null);
 	}
 
+	/**
+	 * Sets the maximum number of alert instances to include in a report. A value of zero is treated as unlimited.
+	 */
+	public ApiResponse setOptionMaximumAlertInstances(String numberofinstances) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("numberOfInstances", numberofinstances);
+		return api.callApi("core", "action", "setOptionMaximumAlertInstances", map);
+	}
+
+	/**
+	 * Sets whether or not related alerts will be merged in any reports generated.
+	 */
+	public ApiResponse setOptionMergeRelatedAlerts(String enabled) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("enabled", enabled);
+		return api.callApi("core", "action", "setOptionMergeRelatedAlerts", map);
+	}
+
+	/**
+	 * Sets (or clears, if empty) the path to the file with alert overrides.
+	 */
+	public ApiResponse setOptionAlertOverridesFilePath(String filepath) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		if (filepath != null) {
+			map.put("filePath", filepath);
+		}
+		return api.callApi("core", "action", "setOptionAlertOverridesFilePath", map);
+	}
+
+	/**
+	 * Sets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
+	 */
 	public ApiResponse setOptionDefaultUserAgent(String string) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("String", string);
@@ -530,6 +632,9 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 		return api.callApi("core", "action", "setOptionTimeoutInSecs", map);
 	}
 
+	/**
+	 * Sets whether or not the outgoing proxy should be used. The address/hostname of the outgoing proxy must be set to enable this option.
+	 */
 	public ApiResponse setOptionUseProxyChain(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
@@ -547,7 +652,7 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	}
 
 	/**
-	 * Gets the Root CA certificate of the Local Proxy.
+	 * Gets the Root CA certificate used by the local proxies.
 	 */
 	public byte[] rootcert() throws ClientApiException {
 		return api.callApiOther("core", "other", "rootcert", null);
@@ -571,6 +676,13 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 	 */
 	public byte[] htmlreport() throws ClientApiException {
 		return api.callApiOther("core", "other", "htmlreport", null);
+	}
+
+	/**
+	 * Generates a report in JSON format
+	 */
+	public byte[] jsonreport() throws ClientApiException {
+		return api.callApiOther("core", "other", "jsonreport", null);
 	}
 
 	/**
@@ -604,6 +716,15 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
 			map.put("count", count);
 		}
 		return api.callApiOther("core", "other", "messagesHar", map);
+	}
+
+	/**
+	 * Gets the HTTP messages with the given IDs, in HAR format.
+	 */
+	public byte[] messagesHarById(String ids) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("ids", ids);
+		return api.callApiOther("core", "other", "messagesHarById", map);
 	}
 
 	/**

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ForcedUser.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ForcedUser.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Params.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Params.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Script.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Script.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 package org.zaproxy.clientapi.gen;
 
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import org.zaproxy.clientapi.core.ApiResponse;
@@ -73,9 +74,9 @@ public class Script extends org.zaproxy.clientapi.gen.deprecated.ScriptDeprecate
 	}
 
 	/**
-	 * Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description
+	 * Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description, and a charset name to read the script (the charset name is required if the script is not in UTF-8, for example, in ISO-8859-1).
 	 */
-	public ApiResponse load(String scriptname, String scripttype, String scriptengine, String filename, String scriptdescription) throws ClientApiException {
+	public ApiResponse load(String scriptname, String scripttype, String scriptengine, String filename, String scriptdescription, Charset charset) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("scriptName", scriptname);
 		map.put("scriptType", scripttype);
@@ -83,6 +84,9 @@ public class Script extends org.zaproxy.clientapi.gen.deprecated.ScriptDeprecate
 		map.put("fileName", filename);
 		if (scriptdescription != null) {
 			map.put("scriptDescription", scriptdescription);
+		}
+		if (charset != null) {
+			map.put("charset", charset.name());
 		}
 		return api.callApi("script", "action", "load", map);
 	}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Search.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Search.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/SessionManagement.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/SessionManagement.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,17 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 	}
 
 	/**
+	 * Returns a list of the names of the nodes added to the Sites tree by the specified scan.
+	 */
+	public ApiResponse addedNodes(String scanid) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		if (scanid != null) {
+			map.put("scanId", scanid);
+		}
+		return api.callApi("spider", "view", "addedNodes", map);
+	}
+
+	/**
 	 * Gets all the domains that are always in scope. For each domain the following are shown: the index, the value (domain), if enabled, and if specified as a regex.
 	 */
 	public ApiResponse domainsAlwaysInScope() throws ClientApiException {
@@ -124,6 +135,13 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "view", "optionMaxDuration", null);
 	}
 
+	/**
+	 * Gets the maximum size, in bytes, that a response might have to be parsed.
+	 */
+	public ApiResponse optionMaxParseSizeBytes() throws ClientApiException {
+		return api.callApi("spider", "view", "optionMaxParseSizeBytes", null);
+	}
+
 	public ApiResponse optionMaxScansInUI() throws ClientApiException {
 		return api.callApi("spider", "view", "optionMaxScansInUI", null);
 	}
@@ -152,6 +170,13 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 
 	public ApiResponse optionUserAgent() throws ClientApiException {
 		return api.callApi("spider", "view", "optionUserAgent", null);
+	}
+
+	/**
+	 * Gets whether or not a spider process should accept cookies while spidering.
+	 */
+	public ApiResponse optionAcceptCookies() throws ClientApiException {
+		return api.callApi("spider", "view", "optionAcceptCookies", null);
 	}
 
 	public ApiResponse optionHandleODataParametersVisited() throws ClientApiException {
@@ -385,6 +410,15 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		return api.callApi("spider", "action", "setOptionUserAgent", map);
 	}
 
+	/**
+	 * Sets whether or not a spider process should accept cookies while spidering.
+	 */
+	public ApiResponse setOptionAcceptCookies(boolean bool) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("Boolean", Boolean.toString(bool));
+		return api.callApi("spider", "action", "setOptionAcceptCookies", map);
+	}
+
 	public ApiResponse setOptionHandleODataParametersVisited(boolean bool) throws ClientApiException {
 		Map<String, String> map = new HashMap<>();
 		map.put("Boolean", Boolean.toString(bool));
@@ -410,6 +444,15 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 		Map<String, String> map = new HashMap<>();
 		map.put("Integer", Integer.toString(i));
 		return api.callApi("spider", "action", "setOptionMaxDuration", map);
+	}
+
+	/**
+	 * Sets the maximum size, in bytes, that a response might have to be parsed. This allows the spider to skip big responses/files.
+	 */
+	public ApiResponse setOptionMaxParseSizeBytes(int i) throws ClientApiException {
+		Map<String, String> map = new HashMap<>();
+		map.put("Integer", Integer.toString(i));
+		return api.callApi("spider", "action", "setOptionMaxParseSizeBytes", map);
 	}
 
 	public ApiResponse setOptionMaxScansInUI(int i) throws ClientApiException {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Stats.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Stats.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Users.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Users.java
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2017 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/CoreDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/CoreDeprecated.java
@@ -563,4 +563,38 @@ public class CoreDeprecated {
         return api.callApiOther("core", "other", "sendHarRequest", map);
     }
 
+    /**
+     * Gets the alerts raised by ZAP, optionally filtering by URL and paginating with 'start' position and 'count' of alerts
+     */
+    public ApiResponse alerts(String baseurl, String start, String count) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApi("core", "view", "alerts", map);
+    }
+
+    /**
+     * Gets the number of alerts, optionally filtering by URL
+     */
+    public ApiResponse numberOfAlerts(String baseurl) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        return api.callApi("core", "view", "numberOfAlerts", map);
+    }
+
+    /**
+     * Gets the URLs accessed through/by ZAP
+     */
+    public ApiResponse urls() throws ClientApiException {
+        return api.callApi("core", "view", "urls", null);
+    }
 }

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ScriptDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ScriptDeprecated.java
@@ -120,4 +120,18 @@ public class ScriptDeprecated {
         return api.callApi("script", "action", "runStandAloneScript", map);
     }
 
+    /**
+     * Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description
+     */
+    public ApiResponse load(String scriptname, String scripttype, String scriptengine, String filename, String scriptdescription) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("scriptName", scriptname);
+        map.put("scriptType", scripttype);
+        map.put("scriptEngine", scriptengine);
+        map.put("fileName", filename);
+        if (scriptdescription != null) {
+            map.put("scriptDescription", scriptdescription);
+        }
+        return api.callApi("script", "action", "load", map);
+    }
 }


### PR DESCRIPTION
Regenerate core APIs for ZAP version 2.7.0 (some tweaks were done to
keep the API client binary compatible with previous versions).