### PR TITLE
Update OWASP Dependency-Check plugin to 3.0.2

### DIFF
--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -1,11 +1,10 @@
 plugins {
     id "me.champeau.gradle.japicmp" version "0.2.5"
-    id "org.owasp.dependencycheck" version "1.4.4.1"
+    id "org.owasp.dependencycheck" version "3.0.2"
 }
 
 apply plugin: 'maven'
 apply plugin: 'signing'
-apply plugin: 'org.owasp.dependencycheck'
 
 dependencies { compile 'org.jdom:jdom:1.1.3' }
 
@@ -26,6 +25,10 @@ configurations {
 
 dependencies {
     japicmpBaseline ("${project.group}:${project.name}:$versionBC") { force = true }
+}
+
+dependencyCheck {
+    skipConfigurations += "japicmpBaseline"
 }
 
 task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {


### PR DESCRIPTION
Update OWASP Dependency-Check plugin to latest version and set to skip
configuration used for binary compatibility tests (just needs to check
the current version).