### PR TITLE
Add Java 9 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 sudo: false
 
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -34,7 +34,9 @@ dependencyCheck {
 task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
     group 'verification'
     description "Checks artifacts' binary compatibility with latest (released) version '$versionBC'."
-    check.dependsOn 'japicmp'
+    if (!JavaVersion.current().isJava9Compatible()) {
+        check.dependsOn 'japicmp'
+    }
     inputs.file(jar)
 
     oldClasspath = configurations.japicmpBaseline


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 9.
Change japicmp task to not run by default in Java 9 (requires a module).