### PR TITLE
Normalise license header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.diffplug.gradle.spotless" version "3.10.0" apply false
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '4.6'
 }
@@ -6,6 +10,8 @@ apply from: "gradle/compile.gradle"
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'com.diffplug.gradle.spotless'
+
     group = 'org.zaproxy'
 
     version '1.6.0-SNAPSHOT'
@@ -18,4 +24,10 @@ subprojects {
 
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
+
+    spotless {
+        java {
+            licenseHeaderFile "$rootDir/gradle/spotless/license.java"
+        }
+    }
 }

--- a/gradle/spotless/license.java
+++ b/gradle/spotless/license.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The ZAP Development Team
+ * Copyright $YEAR The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.clientapi.ant;
-
-import org.zaproxy.clientapi.core.ApiResponse;
-import org.zaproxy.clientapi.core.ClientApiException;
-
-public class ActiveScanUrlTask extends AbstractActiveScanTask {
-
-	@Override
-	protected ApiResponse startScan() throws ClientApiException {
-		return this.getClientApi().ascan.scan(getUrl(), "false", "false", "", "", "");
-	}
-}

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AbstractActiveScanTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AbstractActiveScanTask.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AccessUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AccessUrlTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ActiveScanSubtreeTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AlertCheckTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AlertCheckTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AlertTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/AlertTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/LoadSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/LoadSessionTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/NewSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/NewSessionTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ReportTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ReportTask.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SaveSessionTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SaveSessionTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/SpiderUrlTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/StopZapTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ZapTask.java
+++ b/subprojects/zap-clientapi-ant/src/main/java/org/zaproxy/clientapi/ant/ZapTask.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi-ant/src/test/java/org/zaproxy/clientapi/ant/BuildTest.java
+++ b/subprojects/zap-clientapi-ant/src/test/java/org/zaproxy/clientapi/ant/BuildTest.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 The Zed Attack Proxy Team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/Test.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/Test.java
@@ -1,3 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2011 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zaproxy.clientapi.examples;
 
 import java.util.ArrayList;

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright the ZAP development team
+ * Copyright 2014 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/Alert.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/Alert.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/AlertsFile.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/AlertsFile.java
@@ -1,3 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zaproxy.clientapi.core;
 
 import org.jdom.Document;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponse.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponse.java
@@ -1,19 +1,21 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.zaproxy.clientapi.core;
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseElement.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseElement.java
@@ -1,19 +1,21 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.zaproxy.clientapi.core;
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseFactory.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseFactory.java
@@ -1,3 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zaproxy.clientapi.core;
 
 import org.w3c.dom.NamedNodeMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseList.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseList.java
@@ -1,19 +1,21 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.zaproxy.clientapi.core;
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseSet.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ApiResponseSet.java
@@ -1,19 +1,21 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.zaproxy.clientapi.core;
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2011 The Zed Attack Proxy Team
+ * Copyright 2011 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiException.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiException.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2012 The Zed Attack Proxy Team
+ * Copyright 2012 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiMain.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiMain.java
@@ -3,13 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2012 The Zed Attack Proxy Team
+ * Copyright 2012 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Acsrf.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AjaxSpider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AjaxSpider.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AlertFilter.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/AlertFilter.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authentication.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authentication.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authorization.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Authorization.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Autoupdate.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Break.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Context.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Context.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ForcedUser.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ForcedUser.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/HttpSessions.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ImportLogFiles.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ImportLogFiles.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Importurls.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Importurls.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Openapi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Openapi.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Params.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Params.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pnh.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pnh.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Replacer.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Replacer.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Reveal.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Reveal.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Script.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Script.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.nio.charset.Charset;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Search.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Search.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Selenium.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Selenium.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2016 the ZAP development team
+ * Copyright 2016 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/SessionManagement.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/SessionManagement.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Stats.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Stats.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Users.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Users.java
@@ -1,14 +1,15 @@
-/* Zed Attack Proxy (ZAP) and its related class files.
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 the ZAP development team
+ * Copyright 2017 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.zaproxy.clientapi.gen;
 
 import java.util.HashMap;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AcsrfDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AcsrfDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AjaxSpiderDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AjaxSpiderDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AscanDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AscanDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthenticationDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthenticationDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthorizationDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AuthorizationDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AutoupdateDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AutoupdateDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/BreakDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/BreakDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ContextDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ContextDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/CoreDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/CoreDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ForcedUserDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ForcedUserDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/HttpSessionsDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/HttpSessionsDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ImportLogFilesDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ImportLogFilesDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PnhDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PnhDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PscanDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/PscanDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/RevealDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/RevealDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ScriptDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ScriptDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SearchDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SearchDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SeleniumDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SeleniumDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SessionManagementDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SessionManagementDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SpiderDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SpiderDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/StatsDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/StatsDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/UsersDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/UsersDeprecated.java
@@ -1,10 +1,10 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2017 The ZAP Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Normalise the license header in all Java classes.
Add Spotless Gradle plugin and the license header for Java source files,
to ensure all Java source files have the expected license header.