### PR TITLE
Explicitly disable HTTP cache in ClientApi

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Summary of the changes done in each version.
 
 ## 1.6.0 (Not yet released)
 
+### Changes
+
+ - Explicitly disable HTTP caching, to always obtain a fresh response from ZAP.
 
 ## 1.5.0 (2017-11-30)
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -351,6 +351,7 @@ public class ClientApi {
 
     private InputStream getConnectionInputStream(HttpRequest request) throws IOException {
         HttpURLConnection uc = (HttpURLConnection) request.getRequestUri().openConnection(proxy);
+        uc.setUseCaches(false);
         for (Entry<String, String> header : request.getHeaders().entrySet()) {
             uc.setRequestProperty(header.getKey(), header.getValue());
         }


### PR DESCRIPTION
Change the ClientApi to disable the HTTP cache, while the API responses
shouldn't be cached it seems they were, sometimes, which broke some use
cases (e.g. poll the status of a scan).

Related to zaproxy/zaproxy#4462 - ZAP Jenkins plugin does not obtain
latest spider status