### PR TITLE
Correct form-based authentication example

### DIFF
--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
@@ -90,7 +90,7 @@ public class FormBasedAuthentication {
                                 + "' config param: "
                                 + set.getValue("name")
                                 + " ("
-                                + (set.getValue("mandatory").equals("true")
+                                + (set.getStringValue("mandatory").equals("true")
                                         ? "mandatory"
                                         : "optional")
                                 + ")");
@@ -110,7 +110,7 @@ public class FormBasedAuthentication {
         for (ApiResponse r : configParamsList.getItems()) {
             ApiResponseSet set = (ApiResponseSet) r;
             sb.append(set.getValue("name")).append(" (");
-            sb.append((set.getValue("mandatory").equals("true") ? "mandatory" : "optional"));
+            sb.append((set.getStringValue("mandatory").equals("true") ? "mandatory" : "optional"));
             sb.append("), ");
         }
         System.out.println(sb.deleteCharAt(sb.length() - 2).toString());


### PR DESCRIPTION
Change FormBasedAuthentication to correct the method used to obtain the
data from the API response to compare with correct type (String instead
of ApiResponse), which caused the mandatory parameters to be reported
as optional.