### PR TITLE
Migrate to java-library plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ task wrapper(type: Wrapper) {
 apply from: "gradle/compile.gradle"
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'com.diffplug.gradle.spotless'
 
     group = 'org.zaproxy'

--- a/subprojects/zap-clientapi-ant/zap-clientapi-ant.gradle
+++ b/subprojects/zap-clientapi-ant/zap-clientapi-ant.gradle
@@ -1,10 +1,10 @@
 
 dependencies {
-    compile project(':zap-clientapi')
+    implementation project(':zap-clientapi')
     compileOnly 'org.apache.ant:ant:1.9.7'
 
-    testCompile 'org.apache.ant:ant-testutil:1.9.7'
-    testCompile 'org.nanohttpd:nanohttpd:2.3.1'
+    testImplementation 'org.apache.ant:ant-testutil:1.9.7'
+    testImplementation 'org.nanohttpd:nanohttpd:2.3.1'
 }
 
 sourceSets { examples }

--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -6,7 +6,10 @@ plugins {
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-dependencies { compile 'org.jdom:jdom:1.1.3' }
+dependencies {
+    // XXX Change to implementation (it's not exposed in public API) when bumping major version.
+    api 'org.jdom:jdom:1.1.3'
+}
 
 sourceSets { examples }
 
@@ -40,7 +43,7 @@ task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
     inputs.file(jar)
 
     oldClasspath = configurations.japicmpBaseline
-    newClasspath = configurations.runtime + files(jar)
+    newClasspath = configurations.runtimeClasspath + files(jar)
     onlyBinaryIncompatibleModified = true
     failOnModification = true
     ignoreMissingClasses = true


### PR DESCRIPTION
The java-library plugin gives more control on how the dependencies are
exposed to consumers of the API client, update dependency declarations
accordingly.