### PR TITLE
Fix configuration of examples sourceset

### DIFF
--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -6,12 +6,16 @@ plugins {
 apply plugin: 'maven'
 apply plugin: 'signing'
 
+sourceSets { examples }
+
+assemble.dependsOn examplesClasses
+
 dependencies {
     // XXX Change to implementation (it's not exposed in public API) when bumping major version.
     api 'org.jdom:jdom:1.1.3'
-}
 
-sourceSets { examples }
+    examplesImplementation sourceSets.main.output
+}
 
 jar {
     manifest {


### PR DESCRIPTION
Configure examples sourceset to use the main sourceset and ensure the
examples are compiled.