### PR TITLE
Add Java 10 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -41,7 +41,8 @@ dependencyCheck {
 task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
     group 'verification'
     description "Checks artifacts' binary compatibility with latest (released) version '$versionBC'."
-    if (!JavaVersion.current().isJava9Compatible()) {
+    // XXX Don't run by default with Java 9+, does not work (needs the module java.xml.bind). 
+    if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
         check.dependsOn 'japicmp'
     }
     inputs.files(jar)


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 10.
Add a task/note about why japicmp is not run with newer Java versions.