### PR TITLE
Add Java 11 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+  - openjdk11
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Change .travis.yml to run the build with Java 11, also, remove Java 9
and 10 as they will be soon superseded by Java 11.