### PR TITLE
Fix misc issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Disable XXE processing when parsing ZAP API responses.
+- Ensure alerts file is always closed.
 
 ## [1.6.0] - 2018-04-10
 ### Added

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/AlertsFile.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/AlertsFile.java
@@ -20,8 +20,9 @@
 package org.zaproxy.clientapi.core;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import org.jdom.Document;
@@ -77,8 +78,8 @@ public class AlertsFile {
         XMLOutputter xmlOutput = new XMLOutputter();
 
         xmlOutput.setFormat(Format.getPrettyFormat());
-        try {
-            xmlOutput.output(doc, new FileWriter(outputFile));
+        try (OutputStream os = Files.newOutputStream(outputFile.toPath())) {
+            xmlOutput.output(doc, os);
             System.out.println("alert xml report saved to: " + outputFile.getAbsolutePath());
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Change ClientApi to disable XXE processing (same as in ZAP) when parsing
ZAP API responses, not needed.
Change AlertsFile to close the file with try-with-resource statement to
ensure it is always closed.
Update CHANGELOG.md.

Issues reported by `lgtm.com`.