### PR TITLE
Don't print exception when saving alerts

### DIFF
--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/AlertsFile.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/AlertsFile.java
@@ -73,7 +73,7 @@ public class AlertsFile {
         writeAlertsToFile(outputFile, alertsDocument);
     }
 
-    private static void writeAlertsToFile(File outputFile, Document doc) {
+    private static void writeAlertsToFile(File outputFile, Document doc) throws IOException {
 
         XMLOutputter xmlOutput = new XMLOutputter();
 
@@ -81,8 +81,6 @@ public class AlertsFile {
         try (OutputStream os = Files.newOutputStream(outputFile.toPath())) {
             xmlOutput.output(doc, os);
             System.out.println("alert xml report saved to: " + outputFile.getAbsolutePath());
-        } catch (IOException e) {
-            e.printStackTrace();
         }
     }
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -230,7 +230,7 @@ public class ClientApi {
                     results.get("ignoredAlerts"),
                     outputFile);
         } catch (Exception e) {
-            throw new ClientApiException(e);
+            throw new ClientApiException("Failed to save the alerts:", e);
         }
         if (alertsFound > 0 || alertsNotFound > 0) {
             throw new ClientApiException("Check Alerts Failed!\n" + resultsString);


### PR DESCRIPTION
Change AlertsFile to not print the exception, instead let it be handled
by caller code (as it's already doing).
Change ClientApi to provide a custom message when failed to save the
alerts.