### PR TITLE
Add Error Prone to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath JavaVersion.current() == JavaVersion.VERSION_1_8 ? "net.ltgt.gradle:gradle-errorprone-plugin:0.0.16" : "net.ltgt.gradle:gradle-errorprone-javacplugin-plugin:0.3"
+    }
+}
+
 plugins {
     id "com.diffplug.gradle.spotless" version "3.13.0" apply false
 }
@@ -12,6 +21,7 @@ apply from: "gradle/compile.gradle"
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'com.diffplug.gradle.spotless'
+    apply plugin: JavaVersion.current() == JavaVersion.VERSION_1_8 ? "net.ltgt.errorprone" : "net.ltgt.errorprone-javacplugin"
 
     group = 'org.zaproxy'
 
@@ -32,5 +42,9 @@ subprojects {
 
             googleJavaFormat().style('AOSP')
         }
+    }
+
+    dependencies {
+        errorprone 'com.google.errorprone:error_prone_core:2.3.1'
     }
 }

--- a/subprojects/zap-clientapi-ant/src/test/java/org/zaproxy/clientapi/ant/BuildTest.java
+++ b/subprojects/zap-clientapi-ant/src/test/java/org/zaproxy/clientapi/ant/BuildTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.clientapi.ant;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import fi.iki.elonen.NanoHTTPD;
 import java.io.File;
@@ -126,6 +127,7 @@ public class BuildTest {
     public void shouldExecuteTargetAlertCheck() {
         try {
             buildRule.executeTarget("alertCheck");
+            fail("Expected BuildException.");
         } catch (BuildException e) {
             assertTrue(e.getCause() instanceof ClientApiException);
             assertTrue(e.getCause().getMessage().startsWith("Not found 1 alerts"));

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/SimpleExample.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.clientapi.examples;
 
+import java.nio.charset.StandardCharsets;
 import org.zaproxy.clientapi.core.ApiResponse;
 import org.zaproxy.clientapi.core.ApiResponseElement;
 import org.zaproxy.clientapi.core.ClientApi;
@@ -89,7 +90,7 @@ public class SimpleExample {
             System.out.println("Active Scan complete");
 
             System.out.println("Alerts:");
-            System.out.println(new String(api.core.xmlreport()));
+            System.out.println(new String(api.core.xmlreport(), StandardCharsets.UTF_8));
 
         } catch (Exception e) {
             System.out.println("Exception : " + e.getMessage());

--- a/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
+++ b/subprojects/zap-clientapi/src/examples/java/org/zaproxy/clientapi/examples/authentication/FormBasedAuthentication.java
@@ -21,7 +21,7 @@ package org.zaproxy.clientapi.examples.authentication;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import org.zaproxy.clientapi.core.ApiResponse;
 import org.zaproxy.clientapi.core.ApiResponseElement;
@@ -66,7 +66,7 @@ public class FormBasedAuthentication {
 
     private static void listAuthInformation(ClientApi clientApi) throws ClientApiException {
         // Check out which authentication methods are supported by the API
-        List<String> supportedMethodNames = new LinkedList<>();
+        List<String> supportedMethodNames = new ArrayList<>();
         ApiResponseList authMethodsList =
                 (ApiResponseList) clientApi.authentication.getSupportedAuthenticationMethods();
         for (ApiResponse authMethod : authMethodsList.getItems()) {

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -35,6 +35,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -305,9 +306,9 @@ public class ClientApi {
             HttpURLConnection uc = (HttpURLConnection) url.openConnection(proxy);
             uc.connect();
 
-            BufferedReader in;
-            try {
-                in = new BufferedReader(new InputStreamReader(uc.getInputStream()));
+            try (BufferedReader in =
+                    new BufferedReader(
+                            new InputStreamReader(uc.getInputStream(), StandardCharsets.UTF_8))) {
                 String inputLine;
 
                 while ((inputLine = in.readLine()) != null) {
@@ -315,7 +316,6 @@ public class ClientApi {
                         debugStream.println(inputLine);
                     }
                 }
-                in.close();
 
             } catch (IOException e) {
                 // Ignore
@@ -468,7 +468,7 @@ public class ClientApi {
     /**
      * Adds the given regular expression to the exclusion list of the given context.
      *
-     * @param apikey the API key, might be {@code null}.
+     * @param apiKey the API key, might be {@code null}.
      * @param contextName the name of the context.
      * @param regex the regular expression to add.
      * @throws Exception if an error occurred while calling the API.
@@ -476,15 +476,15 @@ public class ClientApi {
      * @see #context
      */
     @Deprecated
-    public void addExcludeFromContext(String apikey, String contextName, String regex)
+    public void addExcludeFromContext(String apiKey, String contextName, String regex)
             throws Exception {
-        context.excludeFromContext(apikey, contextName, regex);
+        context.excludeFromContext(apiKey, contextName, regex);
     }
 
     /**
      * Adds the given regular expression to the inclusion list of the given context.
      *
-     * @param apikey the API key, might be {@code null}.
+     * @param apiKey the API key, might be {@code null}.
      * @param contextName the name of the context.
      * @param regex the regular expression to add.
      * @throws Exception if an error occurred while calling the API.
@@ -492,9 +492,9 @@ public class ClientApi {
      * @see #context
      */
     @Deprecated
-    public void addIncludeInContext(String apikey, String contextName, String regex)
+    public void addIncludeInContext(String apiKey, String contextName, String regex)
             throws Exception {
-        context.includeInContext(apikey, contextName, regex);
+        context.includeInContext(apiKey, contextName, regex);
     }
 
     /**
@@ -503,21 +503,21 @@ public class ClientApi {
      *
      * <p>Nodes that do not match the regular expression are excluded.
      *
-     * @param apikey the API key, might be {@code null}.
+     * @param apiKey the API key, might be {@code null}.
      * @param contextName the name of the context.
      * @param regex the regular expression to match the node/URL.
      * @throws Exception if an error occurred while calling the API.
      * @deprecated (1.1.0) Use {@link #includeOneMatchingNodeInContext(String, String)} instead.
      */
     @Deprecated
-    public void includeOneMatchingNodeInContext(String apikey, String contextName, String regex)
+    public void includeOneMatchingNodeInContext(String apiKey, String contextName, String regex)
             throws Exception {
         List<String> sessionUrls = getSessionUrls();
         boolean foundOneMatch = false;
         for (String sessionUrl : sessionUrls) {
             if (sessionUrl.matches(regex)) {
                 if (foundOneMatch) {
-                    addExcludeFromContext(apikey, contextName, sessionUrl);
+                    addExcludeFromContext(apiKey, contextName, sessionUrl);
                 } else {
                     foundOneMatch = true;
                 }
@@ -577,15 +577,15 @@ public class ClientApi {
      *
      * <p>The method returns only after the scan has finished.
      *
-     * @param apikey the API key, might be {@code null}.
+     * @param apiKey the API key, might be {@code null}.
      * @param url the site to scan
      * @throws Exception if an error occurred while calling the API.
      * @deprecated (1.1.0) Use {@link #activeScanSiteInScope(String)} instead, the API key should be
      *     set using one of the {@code ClientApi} constructors.
      */
     @Deprecated
-    public void activeScanSiteInScope(String apikey, String url) throws Exception {
-        ascan.scan(apikey, url, "true", "true", "", "", "");
+    public void activeScanSiteInScope(String apiKey, String url) throws Exception {
+        ascan.scan(apiKey, url, "true", "true", "", "", "");
         waitForAScanToFinish(url);
     }
 

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiMain.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApiMain.java
@@ -194,7 +194,7 @@ public class ClientApiMain {
             }
             setTask(args[0]);
             for (String arg : args) {
-                String[] pair = arg.split("=");
+                String[] pair = arg.split("=", 2);
                 if (pair.length == 2) {
                     if (pair[0].equalsIgnoreCase("zapaddr")) {
                         zapaddr = pair[1];
@@ -247,7 +247,6 @@ public class ClientApiMain {
                             + "\tsaveSession\n"
                             + "\tnewSession\n";
         } else {
-            // TODO add case for activeScanSiteInScope
             switch (task) {
                 case stop:
                     help =
@@ -315,9 +314,18 @@ public class ClientApiMain {
                             "usage: activeScanUrl url={url} [zapaddr={ip}] [zapport={port}]\n\n"
                                     + "Examples:\n\t"
                                     + "1. Type 'java -jar zap-api.jar activeScanUrl url=http://myurl.com/' \n\t\t"
-                                    + "Execute and active scan on http://myurl.com/ using zap listening on localhost:8090\n\t"
+                                    + "Execute an active scan on http://myurl.com/ using zap listening on localhost:8090\n\t"
                                     + "2. Type 'java -jar zap-api.jar activeScanUrl url=http://myurl.com/' zapaddr=192.168.1.1 zapport=7080' \n\t\t"
-                                    + "Execute and active scan on http://myurl.com/ using zap listening on 192.168.1.1:7080\n\t";
+                                    + "Execute an active scan on http://myurl.com/ using zap listening on 192.168.1.1:7080\n\t";
+                    break;
+                case activeScanSiteInScope:
+                    help =
+                            "usage: activeScanSiteInScope url={url} [zapaddr={ip}] [zapport={port}]\n\n"
+                                    + "Examples:\n\t"
+                                    + "1. Type 'java -jar zap-api.jar activeScanSiteInScope url=http://example.com/' \n\t\t"
+                                    + "Execute an active scan for URLs in scope under http://example.com/ using zap listening on localhost:8090\n\t"
+                                    + "2. Type 'java -jar zap-api.jar activeScanSiteInScope url=http://example.com/' zapaddr=192.168.1.1 zapport=7080' \n\t\t"
+                                    + "Execute an active scan for URLs in scope under http://example.com/ using zap listening on 192.168.1.1:7080\n\t";
                     break;
                 case addExcludeRegexToContext:
                     help =


### PR DESCRIPTION
Change build.gradle to use Error Prone when compiling.
Address warnings reported by Error Prone:
 - Add missing fail to BuildTest.shouldExecuteTargetAlertCheck to ensure
 that the test does not pass if the expected exception is not thrown
 (MissingFail).
 - Change SimpleExample to not rely on default charset when writing the
 report (DefaultCharset).
 - Change FormBasedAuthentication to use ArrayList instead of LinkedList
 (JdkObsolete).
 - Change ClientApi to not rely on default charset when reading the
 proxied response (DefaultCharset), also, use try-with-resource
 statement to close the input stream, and normalise case of API key
 parameters (InconsistentCapitalization).
 - Change ClientApiMain to split the command line arguments with a limit
 (StringSplitter) and add a missing case to the tasks' help
 (MissingCasesInEnumSwitch), also, fix a typo in existing help task.