### PR TITLE
Correct gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=lf
+* text=auto eol=lf
 
 *.java text
 *.properties text
@@ -6,7 +6,7 @@
 *.xml text
 *.gradle text
 
-*.bat text eol=crlf
+*.bat eol=crlf
 *.sh text
 gradlew text
 


### PR DESCRIPTION
Correct default text declaration.
Remove redundant text attribute in bat files.