### PR TITLE
Use just OpenJDK in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 before_cache:


### PR DESCRIPTION
Replace OracleJDK with OpenJDK, the former is no longer included by
default in newer dists (Xenial).