### PR TITLE
Update link in the POM

### DIFF
--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -107,7 +107,7 @@ publishing {
 
                 organization {
                     name = 'OWASP'
-                    url = 'https://www.owasp.org/index.php/ZAP'
+                    url = 'https://www.zaproxy.org/'
                 }
 
                 mailingLists {


### PR DESCRIPTION
Link to the site instead of the OWASP wiki page.