### PR TITLE
Add/update APIs of add-ons and core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the APIs of the following add-ons:
+  - Import/Export version 0.3.0;
+  - Network version 0.3.0;
+  - Spider version 0.1.0.
+
 ### Changed
+- Update core APIs for 2.12.
 - Update the APIs of the following add-ons:
   - Automation Framework version 0.15.0;
   - Selenium version 15.8.0;
+  - Replacer version 11.
+
+### Deprecated
+- The following APIs were deprecated:
+  - `ImportLogFiles`;
+  - `Importurls`;
+  - `LocalProxies`.
 
 ### Fixed 
 - Add a graphql object to ClientApi.

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -59,13 +59,12 @@ import org.zaproxy.clientapi.gen.Autoupdate;
 import org.zaproxy.clientapi.gen.Break;
 import org.zaproxy.clientapi.gen.Context;
 import org.zaproxy.clientapi.gen.Core;
+import org.zaproxy.clientapi.gen.Exim;
 import org.zaproxy.clientapi.gen.Exportreport;
 import org.zaproxy.clientapi.gen.ForcedUser;
 import org.zaproxy.clientapi.gen.Graphql;
 import org.zaproxy.clientapi.gen.HttpSessions;
-import org.zaproxy.clientapi.gen.ImportLogFiles;
-import org.zaproxy.clientapi.gen.Importurls;
-import org.zaproxy.clientapi.gen.LocalProxies;
+import org.zaproxy.clientapi.gen.Network;
 import org.zaproxy.clientapi.gen.Openapi;
 import org.zaproxy.clientapi.gen.Params;
 import org.zaproxy.clientapi.gen.Pnh;
@@ -119,13 +118,25 @@ public class ClientApi {
     public Break brk = new Break(this);
     public Context context = new Context(this);
     public Core core = new Core(this);
+    public Exim exim = new Exim(this);
     public Exportreport exportreport = new Exportreport(this);
     public ForcedUser forcedUser = new ForcedUser(this);
     public Graphql graphql = new Graphql(this);
     public HttpSessions httpSessions = new HttpSessions(this);
-    public ImportLogFiles logImportFiles = new ImportLogFiles(this);
-    public Importurls importurls = new Importurls(this);
-    public LocalProxies localProxies = new LocalProxies(this);
+
+    @SuppressWarnings("deprecation")
+    public org.zaproxy.clientapi.gen.ImportLogFiles logImportFiles =
+            new org.zaproxy.clientapi.gen.ImportLogFiles(this);
+
+    @SuppressWarnings("deprecation")
+    public org.zaproxy.clientapi.gen.Importurls importurls =
+            new org.zaproxy.clientapi.gen.Importurls(this);
+
+    @SuppressWarnings("deprecation")
+    public org.zaproxy.clientapi.gen.LocalProxies localProxies =
+            new org.zaproxy.clientapi.gen.LocalProxies(this);
+
+    public Network network = new Network(this);
     public Openapi openapi = new Openapi(this);
     public Params params = new Params(this);
     public Pnh pnh = new Pnh(this);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Ascan.java
@@ -85,9 +85,7 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
         return api.callApi("ascan", "view", "excludedFromScan", null);
     }
 
-    /**
-     * Gets the scanners, optionally, of the given scan policy and/or scanner policy/category ID.
-     */
+    /** Gets the scan rules, optionally, of the given scan policy or scanner policy/category ID. */
     public ApiResponse scanners(String scanpolicyname, String policyid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         if (scanpolicyname != null) {
@@ -253,9 +251,9 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
     }
 
     /**
-     * Runs the active scanner against the given URL and/or Context. Optionally, the 'recurse'
-     * parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be
-     * used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the
+     * Runs the active scanner against the given URL or Context. Optionally, the 'recurse' parameter
+     * can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to
+     * constrain the scan to URLs that are in scope (ignored if a Context is specified), the
      * parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the
      * default scan policy), the parameters 'method' and 'postData' allow to select a given request
      * in conjunction with the given URL.
@@ -385,7 +383,7 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
     }
 
     /**
-     * Enables all scanners of the scan policy with the given name, or the default if none given.
+     * Enables all scan rules of the scan policy with the given name, or the default if none given.
      */
     public ApiResponse enableAllScanners(String scanpolicyname) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -396,7 +394,7 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
     }
 
     /**
-     * Disables all scanners of the scan policy with the given name, or the default if none given.
+     * Disables all scan rules of the scan policy with the given name, or the default if none given.
      */
     public ApiResponse disableAllScanners(String scanpolicyname) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -407,8 +405,8 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
     }
 
     /**
-     * Enables the scanners with the given IDs (comma separated list of IDs) of the scan policy with
-     * the given name, or the default if none given.
+     * Enables the scan rules with the given IDs (comma separated list of IDs) of the scan policy
+     * with the given name, or the default if none given.
      */
     public ApiResponse enableScanners(String ids, String scanpolicyname) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -420,7 +418,7 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
     }
 
     /**
-     * Disables the scanners with the given IDs (comma separated list of IDs) of the scan policy
+     * Disables the scan rules with the given IDs (comma separated list of IDs) of the scan policy
      * with the given name, or the default if none given.
      */
     public ApiResponse disableScanners(String ids, String scanpolicyname)
@@ -485,10 +483,6 @@ public class Ascan extends org.zaproxy.clientapi.gen.deprecated.AscanDeprecated 
             map.put("scanPolicyName", scanpolicyname);
         }
         return api.callApi("ascan", "action", "setScannerAlertThreshold", map);
-    }
-
-    public ApiResponse addScanPolicy(String scanpolicyname) throws ClientApiException {
-        return addScanPolicy(scanpolicyname, null, null);
     }
 
     public ApiResponse addScanPolicy(

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Core.java
@@ -132,7 +132,10 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Gets all the domains that are excluded from the outgoing proxy. For each domain the following
      * are shown: the index, the value (domain), if enabled, and if specified as a regex.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse proxyChainExcludedDomains() throws ClientApiException {
         return api.callApi("core", "view", "proxyChainExcludedDomains", null);
     }
@@ -265,66 +268,106 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Gets the user agent that ZAP should use when creating HTTP messages (for example, spider
      * messages or CONNECT requests to outgoing proxy).
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse optionDefaultUserAgent() throws ClientApiException {
         return api.callApi("core", "view", "optionDefaultUserAgent", null);
     }
 
-    /** Gets the TTL (in seconds) of successful DNS queries. */
+    /**
+     * Gets the TTL (in seconds) of successful DNS queries.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse optionDnsTtlSuccessfulQueries() throws ClientApiException {
         return api.callApi("core", "view", "optionDnsTtlSuccessfulQueries", null);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse optionHttpState() throws ClientApiException {
         return api.callApi("core", "view", "optionHttpState", null);
     }
 
-    public ApiResponse optionProxyChainName() throws ClientApiException {
-        return api.callApi("core", "view", "optionProxyChainName", null);
-    }
-
-    public ApiResponse optionProxyChainPassword() throws ClientApiException {
-        return api.callApi("core", "view", "optionProxyChainPassword", null);
-    }
-
-    public ApiResponse optionProxyChainPort() throws ClientApiException {
-        return api.callApi("core", "view", "optionProxyChainPort", null);
-    }
-
-    public ApiResponse optionProxyChainRealm() throws ClientApiException {
-        return api.callApi("core", "view", "optionProxyChainRealm", null);
-    }
-
-    public ApiResponse optionProxyChainUserName() throws ClientApiException {
-        return api.callApi("core", "view", "optionProxyChainUserName", null);
-    }
-
-    /** Gets the connection time out (in seconds). */
-    public ApiResponse optionTimeoutInSecs() throws ClientApiException {
-        return api.callApi("core", "view", "optionTimeoutInSecs", null);
-    }
-
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse optionHttpStateEnabled() throws ClientApiException {
         return api.callApi("core", "view", "optionHttpStateEnabled", null);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse optionProxyChainName() throws ClientApiException {
+        return api.callApi("core", "view", "optionProxyChainName", null);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse optionProxyChainPassword() throws ClientApiException {
+        return api.callApi("core", "view", "optionProxyChainPassword", null);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse optionProxyChainPort() throws ClientApiException {
+        return api.callApi("core", "view", "optionProxyChainPort", null);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse optionProxyChainPrompt() throws ClientApiException {
         return api.callApi("core", "view", "optionProxyChainPrompt", null);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse optionProxyChainRealm() throws ClientApiException {
+        return api.callApi("core", "view", "optionProxyChainRealm", null);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse optionProxyChainUserName() throws ClientApiException {
+        return api.callApi("core", "view", "optionProxyChainUserName", null);
+    }
+
+    /** @deprecated Option no longer in effective use. */
+    @Deprecated
     public ApiResponse optionSingleCookieRequestHeader() throws ClientApiException {
         return api.callApi("core", "view", "optionSingleCookieRequestHeader", null);
     }
 
+    /**
+     * Gets the connection time out (in seconds).
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
+    public ApiResponse optionTimeoutInSecs() throws ClientApiException {
+        return api.callApi("core", "view", "optionTimeoutInSecs", null);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse optionUseProxyChain() throws ClientApiException {
         return api.callApi("core", "view", "optionUseProxyChain", null);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse optionUseProxyChainAuth() throws ClientApiException {
         return api.callApi("core", "view", "optionUseProxyChainAuth", null);
     }
 
-    /** Gets whether or not the SOCKS proxy should be used. */
+    /**
+     * Gets whether or not the SOCKS proxy should be used.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse optionUseSocksProxy() throws ClientApiException {
         return api.callApi("core", "view", "optionUseSocksProxy", null);
     }
@@ -425,7 +468,12 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
         return api.callApi("core", "action", "setMode", map);
     }
 
-    /** Generates a new Root CA certificate for the local proxies. */
+    /**
+     * Generates a new Root CA certificate for the local proxies.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse generateRootCA() throws ClientApiException {
         return api.callApi("core", "action", "generateRootCA", null);
     }
@@ -471,7 +519,10 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
      * Adds a domain to be excluded from the outgoing proxy, using the specified value. Optionally
      * sets if the new entry is enabled (default, true) and whether or not the new value is
      * specified as a regex (default, false).
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse addProxyChainExcludedDomain(String value, String isregex, String isenabled)
             throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -489,7 +540,10 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
      * Modifies a domain excluded from the outgoing proxy. Allows to modify the value, if enabled or
      * if a regex. The domain is selected with its index, which can be obtained with the view
      * proxyChainExcludedDomains.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse modifyProxyChainExcludedDomain(
             String idx, String value, String isregex, String isenabled) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -509,19 +563,32 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Removes a domain excluded from the outgoing proxy, with the given index. The index can be
      * obtained with the view proxyChainExcludedDomains.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse removeProxyChainExcludedDomain(String idx) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("idx", idx);
         return api.callApi("core", "action", "removeProxyChainExcludedDomain", map);
     }
 
-    /** Enables all domains excluded from the outgoing proxy. */
+    /**
+     * Enables all domains excluded from the outgoing proxy.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse enableAllProxyChainExcludedDomains() throws ClientApiException {
         return api.callApi("core", "action", "enableAllProxyChainExcludedDomains", null);
     }
 
-    /** Disables all domains excluded from the outgoing proxy. */
+    /**
+     * Disables all domains excluded from the outgoing proxy.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse disableAllProxyChainExcludedDomains() throws ClientApiException {
         return api.callApi("core", "action", "disableAllProxyChainExcludedDomains", null);
     }
@@ -556,7 +623,10 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Enables use of a PKCS12 client certificate for the certificate with the given file system
      * path, password, and optional index.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse enablePKCS12ClientCertificate(String filepath, String password, String index)
             throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -568,7 +638,12 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
         return api.callApi("core", "action", "enablePKCS12ClientCertificate", map);
     }
 
-    /** Disables the option for use of client certificates. */
+    /**
+     * Disables the option for use of client certificates.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse disableClientCertificate() throws ClientApiException {
         return api.callApi("core", "action", "disableClientCertificate", null);
     }
@@ -598,25 +673,70 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Sets the user agent that ZAP should use when creating HTTP messages (for example, spider
      * messages or CONNECT requests to outgoing proxy).
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse setOptionDefaultUserAgent(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("core", "action", "setOptionDefaultUserAgent", map);
     }
 
+    /**
+     * Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
+    public ApiResponse setOptionDnsTtlSuccessfulQueries(int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("core", "action", "setOptionDnsTtlSuccessfulQueries", map);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse setOptionHttpStateEnabled(boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionHttpStateEnabled", map);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse setOptionProxyChainName(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("core", "action", "setOptionProxyChainName", map);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse setOptionProxyChainPassword(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("core", "action", "setOptionProxyChainPassword", map);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse setOptionProxyChainPort(int i) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("Integer", Integer.toString(i));
+        return api.callApi("core", "action", "setOptionProxyChainPort", map);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
+    public ApiResponse setOptionProxyChainPrompt(boolean bool) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("Boolean", Boolean.toString(bool));
+        return api.callApi("core", "action", "setOptionProxyChainPrompt", map);
+    }
+
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse setOptionProxyChainRealm(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
@@ -635,44 +755,28 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
         return api.callApi("core", "action", "setOptionProxyChainSkipName", map);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse setOptionProxyChainUserName(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("core", "action", "setOptionProxyChainUserName", map);
     }
 
-    /** Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart). */
-    public ApiResponse setOptionDnsTtlSuccessfulQueries(int i) throws ClientApiException {
-        Map<String, String> map = new HashMap<>();
-        map.put("Integer", Integer.toString(i));
-        return api.callApi("core", "action", "setOptionDnsTtlSuccessfulQueries", map);
-    }
-
-    public ApiResponse setOptionHttpStateEnabled(boolean bool) throws ClientApiException {
-        Map<String, String> map = new HashMap<>();
-        map.put("Boolean", Boolean.toString(bool));
-        return api.callApi("core", "action", "setOptionHttpStateEnabled", map);
-    }
-
-    public ApiResponse setOptionProxyChainPort(int i) throws ClientApiException {
-        Map<String, String> map = new HashMap<>();
-        map.put("Integer", Integer.toString(i));
-        return api.callApi("core", "action", "setOptionProxyChainPort", map);
-    }
-
-    public ApiResponse setOptionProxyChainPrompt(boolean bool) throws ClientApiException {
-        Map<String, String> map = new HashMap<>();
-        map.put("Boolean", Boolean.toString(bool));
-        return api.callApi("core", "action", "setOptionProxyChainPrompt", map);
-    }
-
+    /** @deprecated Option no longer in effective use. */
+    @Deprecated
     public ApiResponse setOptionSingleCookieRequestHeader(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("core", "action", "setOptionSingleCookieRequestHeader", map);
     }
 
-    /** Sets the connection time out (in seconds). */
+    /**
+     * Sets the connection time out (in seconds).
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse setOptionTimeoutInSecs(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));
@@ -682,35 +786,54 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Sets whether or not the outgoing proxy should be used. The address/hostname of the outgoing
      * proxy must be set to enable this option.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
      */
+    @Deprecated
     public ApiResponse setOptionUseProxyChain(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("core", "action", "setOptionUseProxyChain", map);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public ApiResponse setOptionUseProxyChainAuth(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("core", "action", "setOptionUseProxyChainAuth", map);
     }
 
-    /** Sets whether or not the SOCKS proxy should be used. */
+    /**
+     * Sets whether or not the SOCKS proxy should be used.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public ApiResponse setOptionUseSocksProxy(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("core", "action", "setOptionUseSocksProxy", map);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public byte[] proxypac() throws ClientApiException {
         return api.callApiOther("core", "other", "proxy.pac", null);
     }
 
-    /** Gets the Root CA certificate used by the local proxies. */
+    /**
+     * Gets the Root CA certificate used by the local proxies.
+     *
+     * @deprecated Use the API endpoints in the 'network' component instead.
+     */
+    @Deprecated
     public byte[] rootcert() throws ClientApiException {
         return api.callApiOther("core", "other", "rootcert", null);
     }
 
+    /** @deprecated Use the API endpoints in the 'network' component instead. */
+    @Deprecated
     public byte[] setproxy(String proxy) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("proxy", proxy);
@@ -757,7 +880,12 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
         return api.callApiOther("core", "other", "mdreport", null);
     }
 
-    /** Gets the message with the given ID in HAR format */
+    /**
+     * Gets the message with the given ID in HAR format
+     *
+     * @deprecated Use the API endpoints in the 'exim' add-on instead.
+     */
+    @Deprecated
     public byte[] messageHar(String id) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("id", id);
@@ -767,7 +895,10 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
     /**
      * Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and
      * paginated with 'start' position and 'count' of messages
+     *
+     * @deprecated Use the API endpoints in the 'exim' add-on instead.
      */
+    @Deprecated
     public byte[] messagesHar(String baseurl, String start, String count)
             throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -783,7 +914,12 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
         return api.callApiOther("core", "other", "messagesHar", map);
     }
 
-    /** Gets the HTTP messages with the given IDs, in HAR format. */
+    /**
+     * Gets the HTTP messages with the given IDs, in HAR format.
+     *
+     * @deprecated Use the API endpoints in the 'exim' add-on instead.
+     */
+    @Deprecated
     public byte[] messagesHarById(String ids) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("ids", ids);
@@ -795,7 +931,10 @@ public class Core extends org.zaproxy.clientapi.gen.deprecated.CoreDeprecated {
      * the request sent and response received and followed redirections, if any. The Mode is
      * enforced when sending the request (and following redirections), custom manual requests are
      * not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
+     *
+     * @deprecated Use the API endpoints in the 'exim' add-on instead.
      */
+    @Deprecated
     public byte[] sendHarRequest(String request, String followredirects) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("request", request);

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Exim.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Exim.java
@@ -1,0 +1,129 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** This file was automatically generated. */
+@SuppressWarnings("javadoc")
+public class Exim {
+
+    private final ClientApi api;
+
+    public Exim(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * Imports a HAR file.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse importHar(String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("filePath", filepath);
+        return api.callApi("exim", "action", "importHar", map);
+    }
+
+    /**
+     * Imports URLs (one per line) from the file with the given file system path.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse importUrls(String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("filePath", filepath);
+        return api.callApi("exim", "action", "importUrls", map);
+    }
+
+    /**
+     * Imports previously exported ZAP messages from the file with the given file system path.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse importZapLogs(String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("filePath", filepath);
+        return api.callApi("exim", "action", "importZapLogs", map);
+    }
+
+    /**
+     * Imports ModSecurity2 logs from the file with the given file system path.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse importModsec2Logs(String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("filePath", filepath);
+        return api.callApi("exim", "action", "importModsec2Logs", map);
+    }
+
+    /**
+     * Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and
+     * paginated with 'start' position and 'count' of messages
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public byte[] exportHar(String baseurl, String start, String count) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        if (baseurl != null) {
+            map.put("baseurl", baseurl);
+        }
+        if (start != null) {
+            map.put("start", start);
+        }
+        if (count != null) {
+            map.put("count", count);
+        }
+        return api.callApiOther("exim", "other", "exportHar", map);
+    }
+
+    /**
+     * Gets the HTTP messages with the given IDs, in HAR format.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public byte[] exportHarById(String ids) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("ids", ids);
+        return api.callApiOther("exim", "other", "exportHarById", map);
+    }
+
+    /**
+     * Sends the first HAR request entry, optionally following redirections. Returns, in HAR format,
+     * the request sent and response received and followed redirections, if any. The Mode is
+     * enforced when sending the request (and following redirections), custom manual requests are
+     * not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public byte[] sendHarRequest(String request, String followredirects) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("request", request);
+        if (followredirects != null) {
+            map.put("followRedirects", followredirects);
+        }
+        return api.callApiOther("exim", "other", "sendHarRequest", map);
+    }
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ImportLogFiles.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/ImportLogFiles.java
@@ -25,8 +25,13 @@ import org.zaproxy.clientapi.core.ApiResponse;
 import org.zaproxy.clientapi.core.ClientApi;
 import org.zaproxy.clientapi.core.ClientApiException;
 
-/** This file was automatically generated. */
+/**
+ * This file was automatically generated.
+ *
+ * @deprecated Use {@link Exim} instead.
+ */
 @SuppressWarnings("javadoc")
+@Deprecated
 public class ImportLogFiles extends org.zaproxy.clientapi.gen.deprecated.ImportLogFilesDeprecated {
 
     private final ClientApi api;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Importurls.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Importurls.java
@@ -25,8 +25,13 @@ import org.zaproxy.clientapi.core.ApiResponse;
 import org.zaproxy.clientapi.core.ClientApi;
 import org.zaproxy.clientapi.core.ClientApiException;
 
-/** This file was automatically generated. */
+/**
+ * This file was automatically generated.
+ *
+ * @deprecated Use {@link Exim} instead.
+ */
 @SuppressWarnings("javadoc")
+@Deprecated
 public class Importurls {
 
     private final ClientApi api;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/LocalProxies.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/LocalProxies.java
@@ -25,8 +25,13 @@ import org.zaproxy.clientapi.core.ApiResponse;
 import org.zaproxy.clientapi.core.ClientApi;
 import org.zaproxy.clientapi.core.ClientApiException;
 
-/** This file was automatically generated. */
+/**
+ * This file was automatically generated.
+ *
+ * @deprecated Use {@link Network} instead.
+ */
 @SuppressWarnings("javadoc")
+@Deprecated
 public class LocalProxies {
 
     private final ClientApi api;

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Network.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Network.java
@@ -1,0 +1,565 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** This file was automatically generated. */
+@SuppressWarnings("javadoc")
+public class Network {
+
+    private final ClientApi api;
+
+    public Network(ClientApi api) {
+        this.api = api;
+    }
+
+    /**
+     * Gets the Root CA certificate validity, in days. Used when generating a new Root CA
+     * certificate.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getRootCaCertValidity() throws ClientApiException {
+        return api.callApi("network", "view", "getRootCaCertValidity", null);
+    }
+
+    /**
+     * Gets the server certificate validity, in days. Used when generating server certificates.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getServerCertValidity() throws ClientApiException {
+        return api.callApi("network", "view", "getServerCertValidity", null);
+    }
+
+    /**
+     * Gets the aliases used to identify the local servers/proxies.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getAliases() throws ClientApiException {
+        return api.callApi("network", "view", "getAliases", null);
+    }
+
+    /**
+     * Gets the local servers/proxies.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getLocalServers() throws ClientApiException {
+        return api.callApi("network", "view", "getLocalServers", null);
+    }
+
+    /**
+     * Gets the authorities that will pass-through the local proxies.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getPassThroughs() throws ClientApiException {
+        return api.callApi("network", "view", "getPassThroughs", null);
+    }
+
+    /**
+     * Gets the connection timeout, in seconds.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getConnectionTimeout() throws ClientApiException {
+        return api.callApi("network", "view", "getConnectionTimeout", null);
+    }
+
+    /**
+     * Gets the default user-agent.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getDefaultUserAgent() throws ClientApiException {
+        return api.callApi("network", "view", "getDefaultUserAgent", null);
+    }
+
+    /**
+     * Gets the TTL (in seconds) of successful DNS queries.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getDnsTtlSuccessfulQueries() throws ClientApiException {
+        return api.callApi("network", "view", "getDnsTtlSuccessfulQueries", null);
+    }
+
+    /**
+     * Gets the HTTP proxy.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getHttpProxy() throws ClientApiException {
+        return api.callApi("network", "view", "getHttpProxy", null);
+    }
+
+    /**
+     * Gets the HTTP proxy exclusions.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getHttpProxyExclusions() throws ClientApiException {
+        return api.callApi("network", "view", "getHttpProxyExclusions", null);
+    }
+
+    /**
+     * Gets the SOCKS proxy.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse getSocksProxy() throws ClientApiException {
+        return api.callApi("network", "view", "getSocksProxy", null);
+    }
+
+    /**
+     * Tells whether or not the HTTP proxy authentication is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse isHttpProxyAuthEnabled() throws ClientApiException {
+        return api.callApi("network", "view", "isHttpProxyAuthEnabled", null);
+    }
+
+    /**
+     * Tells whether or not the HTTP proxy is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse isHttpProxyEnabled() throws ClientApiException {
+        return api.callApi("network", "view", "isHttpProxyEnabled", null);
+    }
+
+    /**
+     * Tells whether or not the SOCKS proxy is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse isSocksProxyEnabled() throws ClientApiException {
+        return api.callApi("network", "view", "isSocksProxyEnabled", null);
+    }
+
+    /**
+     * Tells whether or not to use global HTTP state.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse isUseGlobalHttpState() throws ClientApiException {
+        return api.callApi("network", "view", "isUseGlobalHttpState", null);
+    }
+
+    /**
+     * Generates a new Root CA certificate, used to issue server certificates.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse generateRootCaCert() throws ClientApiException {
+        return api.callApi("network", "action", "generateRootCaCert", null);
+    }
+
+    /**
+     * Imports a Root CA certificate to be used to issue server certificates.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse importRootCaCert(String filepath) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("filePath", filepath);
+        return api.callApi("network", "action", "importRootCaCert", map);
+    }
+
+    /**
+     * Sets the Root CA certificate validity. Used when generating a new Root CA certificate.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setRootCaCertValidity(String validity) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("validity", validity);
+        return api.callApi("network", "action", "setRootCaCertValidity", map);
+    }
+
+    /**
+     * Sets the server certificate validity. Used when generating server certificates.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setServerCertValidity(String validity) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("validity", validity);
+        return api.callApi("network", "action", "setServerCertValidity", map);
+    }
+
+    /**
+     * Adds an alias for the local servers/proxies.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse addAlias(String name, String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("name", name);
+        if (enabled != null) {
+            map.put("enabled", enabled);
+        }
+        return api.callApi("network", "action", "addAlias", map);
+    }
+
+    /**
+     * Adds a local server/proxy.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse addLocalServer(
+            String address,
+            String port,
+            String api,
+            String proxy,
+            String behindnat,
+            String decoderesponse,
+            String removeacceptencoding)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("address", address);
+        map.put("port", port);
+        if (api != null) {
+            map.put("api", api);
+        }
+        if (proxy != null) {
+            map.put("proxy", proxy);
+        }
+        if (behindnat != null) {
+            map.put("behindNat", behindnat);
+        }
+        if (decoderesponse != null) {
+            map.put("decodeResponse", decoderesponse);
+        }
+        if (removeacceptencoding != null) {
+            map.put("removeAcceptEncoding", removeacceptencoding);
+        }
+        return this.api.callApi("network", "action", "addLocalServer", map);
+    }
+
+    /**
+     * Adds an authority to pass-through the local proxies.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse addPassThrough(String authority, String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("authority", authority);
+        if (enabled != null) {
+            map.put("enabled", enabled);
+        }
+        return api.callApi("network", "action", "addPassThrough", map);
+    }
+
+    /**
+     * Removes an alias.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse removeAlias(String name) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("name", name);
+        return api.callApi("network", "action", "removeAlias", map);
+    }
+
+    /**
+     * Removes a local server/proxy.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse removeLocalServer(String address, String port) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("address", address);
+        map.put("port", port);
+        return api.callApi("network", "action", "removeLocalServer", map);
+    }
+
+    /**
+     * Removes a pass-through.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse removePassThrough(String authority) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("authority", authority);
+        return api.callApi("network", "action", "removePassThrough", map);
+    }
+
+    /**
+     * Sets whether or not an alias is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setAliasEnabled(String name, String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("name", name);
+        map.put("enabled", enabled);
+        return api.callApi("network", "action", "setAliasEnabled", map);
+    }
+
+    /**
+     * Sets whether or not a pass-through is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setPassThroughEnabled(String authority, String enabled)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("authority", authority);
+        map.put("enabled", enabled);
+        return api.callApi("network", "action", "setPassThroughEnabled", map);
+    }
+
+    /**
+     * Sets the timeout, for reads and connects.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setConnectionTimeout(String timeout) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("timeout", timeout);
+        return api.callApi("network", "action", "setConnectionTimeout", map);
+    }
+
+    /**
+     * Sets the default user-agent.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setDefaultUserAgent(String useragent) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("userAgent", useragent);
+        return api.callApi("network", "action", "setDefaultUserAgent", map);
+    }
+
+    /**
+     * Sets the TTL of successful DNS queries.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setDnsTtlSuccessfulQueries(String ttl) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("ttl", ttl);
+        return api.callApi("network", "action", "setDnsTtlSuccessfulQueries", map);
+    }
+
+    /**
+     * Adds a host to be excluded from the HTTP proxy.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse addHttpProxyExclusion(String host, String enabled)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("host", host);
+        if (enabled != null) {
+            map.put("enabled", enabled);
+        }
+        return api.callApi("network", "action", "addHttpProxyExclusion", map);
+    }
+
+    /**
+     * Removes a HTTP proxy exclusion.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse removeHttpProxyExclusion(String host) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("host", host);
+        return api.callApi("network", "action", "removeHttpProxyExclusion", map);
+    }
+
+    /**
+     * Sets the HTTP proxy configuration.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setHttpProxy(
+            String host, String port, String realm, String username, String password)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("host", host);
+        map.put("port", port);
+        if (realm != null) {
+            map.put("realm", realm);
+        }
+        if (username != null) {
+            map.put("username", username);
+        }
+        if (password != null) {
+            map.put("password", password);
+        }
+        return api.callApi("network", "action", "setHttpProxy", map);
+    }
+
+    /**
+     * Sets whether or not the HTTP proxy authentication is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setHttpProxyAuthEnabled(String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("enabled", enabled);
+        return api.callApi("network", "action", "setHttpProxyAuthEnabled", map);
+    }
+
+    /**
+     * Sets whether or not the HTTP proxy is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setHttpProxyEnabled(String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("enabled", enabled);
+        return api.callApi("network", "action", "setHttpProxyEnabled", map);
+    }
+
+    /**
+     * Sets whether or not a HTTP proxy exclusion is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setHttpProxyExclusionEnabled(String host, String enabled)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("host", host);
+        map.put("enabled", enabled);
+        return api.callApi("network", "action", "setHttpProxyExclusionEnabled", map);
+    }
+
+    /**
+     * Sets the SOCKS proxy configuration.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setSocksProxy(
+            String host,
+            String port,
+            String version,
+            String usedns,
+            String username,
+            String password)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("host", host);
+        map.put("port", port);
+        if (version != null) {
+            map.put("version", version);
+        }
+        if (usedns != null) {
+            map.put("useDns", usedns);
+        }
+        if (username != null) {
+            map.put("username", username);
+        }
+        if (password != null) {
+            map.put("password", password);
+        }
+        return api.callApi("network", "action", "setSocksProxy", map);
+    }
+
+    /**
+     * Sets whether or not the SOCKS proxy is enabled.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setSocksProxyEnabled(String enabled) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("enabled", enabled);
+        return api.callApi("network", "action", "setSocksProxyEnabled", map);
+    }
+
+    /**
+     * Sets whether or not to use the global HTTP state.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setUseGlobalHttpState(String use) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("use", use);
+        return api.callApi("network", "action", "setUseGlobalHttpState", map);
+    }
+
+    /**
+     * Adds a client certificate contained in a PKCS#12 file, the certificate is automatically set
+     * as active and used.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse addPkcs12ClientCertificate(String filepath, String password, String index)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("filePath", filepath);
+        map.put("password", password);
+        if (index != null) {
+            map.put("index", index);
+        }
+        return api.callApi("network", "action", "addPkcs12ClientCertificate", map);
+    }
+
+    /**
+     * Sets whether or not to use the active client certificate.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public ApiResponse setUseClientCertificate(String use) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("use", use);
+        return api.callApi("network", "action", "setUseClientCertificate", map);
+    }
+
+    /**
+     * Provides a PAC file, proxying through the main proxy.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public byte[] proxypac() throws ClientApiException {
+        return api.callApiOther("network", "other", "proxy.pac", null);
+    }
+
+    /**
+     * Sets the HTTP proxy configuration.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public byte[] setProxy(String proxy) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("proxy", proxy);
+        return api.callApiOther("network", "other", "setProxy", map);
+    }
+
+    /**
+     * Gets the Root CA certificate used to issue server certificates. Suitable to import into
+     * client applications (e.g. browsers).
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
+    public byte[] rootCaCert() throws ClientApiException {
+        return api.callApiOther("network", "other", "rootCaCert", null);
+    }
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Pscan.java
@@ -48,14 +48,24 @@ public class Pscan extends org.zaproxy.clientapi.gen.deprecated.PscanDeprecated 
         return api.callApi("pscan", "view", "recordsToScan", null);
     }
 
-    /** Lists all passive scanners with its ID, name, enabled state and alert threshold. */
+    /** Lists all passive scan rules with their ID, name, enabled state, and alert threshold. */
     public ApiResponse scanners() throws ClientApiException {
         return api.callApi("pscan", "view", "scanners", null);
     }
 
-    /** Show information about the passive scan rule currently being run (if any). */
+    /**
+     * Show information about the passive scan rule currently being run (if any).
+     *
+     * @deprecated Use the currentTasks view instead.
+     */
+    @Deprecated
     public ApiResponse currentRule() throws ClientApiException {
         return api.callApi("pscan", "view", "currentRule", null);
+    }
+
+    /** Show information about the passive scan tasks currently being run (if any). */
+    public ApiResponse currentTasks() throws ClientApiException {
+        return api.callApi("pscan", "view", "currentTasks", null);
     }
 
     /** Gets the maximum number of alerts a passive scan rule should raise. */
@@ -82,24 +92,24 @@ public class Pscan extends org.zaproxy.clientapi.gen.deprecated.PscanDeprecated 
         return api.callApi("pscan", "action", "setScanOnlyInScope", map);
     }
 
-    /** Enables all passive scanners */
+    /** Enables all passive scan rules */
     public ApiResponse enableAllScanners() throws ClientApiException {
         return api.callApi("pscan", "action", "enableAllScanners", null);
     }
 
-    /** Disables all passive scanners */
+    /** Disables all passive scan rules */
     public ApiResponse disableAllScanners() throws ClientApiException {
         return api.callApi("pscan", "action", "disableAllScanners", null);
     }
 
-    /** Enables all passive scanners with the given IDs (comma separated list of IDs) */
+    /** Enables all passive scan rules with the given IDs (comma separated list of IDs) */
     public ApiResponse enableScanners(String ids) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("ids", ids);
         return api.callApi("pscan", "action", "enableScanners", map);
     }
 
-    /** Disables all passive scanners with the given IDs (comma separated list of IDs) */
+    /** Disables all passive scan rules with the given IDs (comma separated list of IDs) */
     public ApiResponse disableScanners(String ids) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("ids", ids);
@@ -133,5 +143,10 @@ public class Pscan extends org.zaproxy.clientapi.gen.deprecated.PscanDeprecated 
     /** Enables all passive scan tags. */
     public ApiResponse enableAllTags() throws ClientApiException {
         return api.callApi("pscan", "action", "enableAllTags", null);
+    }
+
+    /** Clears the passive scan queue. */
+    public ApiResponse clearQueue() throws ClientApiException {
+        return api.callApi("pscan", "action", "clearQueue", null);
     }
 }

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Replacer.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Replacer.java
@@ -24,14 +24,16 @@ import java.util.Map;
 import org.zaproxy.clientapi.core.ApiResponse;
 import org.zaproxy.clientapi.core.ClientApi;
 import org.zaproxy.clientapi.core.ClientApiException;
+import org.zaproxy.clientapi.gen.deprecated.ReplacerDeprecated;
 
 /** This file was automatically generated. */
 @SuppressWarnings("javadoc")
-public class Replacer {
+public class Replacer extends ReplacerDeprecated {
 
     private final ClientApi api;
 
     public Replacer(ClientApi api) {
+        super(api);
         this.api = api;
     }
 
@@ -62,7 +64,8 @@ public class Replacer {
             String matchregex,
             String matchstring,
             String replacement,
-            String initiators)
+            String initiators,
+            String url)
             throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("description", description);
@@ -75,6 +78,9 @@ public class Replacer {
         }
         if (initiators != null) {
             map.put("initiators", initiators);
+        }
+        if (url != null) {
+            map.put("url", url);
         }
         return api.callApi("replacer", "action", "addRule", map);
     }

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/Spider.java
@@ -36,6 +36,7 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         this.api = api;
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse status(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         if (scanid != null) {
@@ -44,6 +45,7 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "view", "status", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse results(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         if (scanid != null) {
@@ -52,17 +54,23 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "view", "results", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse fullResults(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("scanId", scanid);
         return api.callApi("spider", "view", "fullResults", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse scans() throws ClientApiException {
         return api.callApi("spider", "view", "scans", null);
     }
 
-    /** Gets the regexes of URLs excluded from the spider scans. */
+    /**
+     * Gets the regexes of URLs excluded from the spider scans.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse excludedFromScan() throws ClientApiException {
         return api.callApi("spider", "view", "excludedFromScan", null);
     }
@@ -70,12 +78,18 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
     /**
      * Returns a list of unique URLs from the history table based on HTTP messages added by the
      * Spider.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse allUrls() throws ClientApiException {
         return api.callApi("spider", "view", "allUrls", null);
     }
 
-    /** Returns a list of the names of the nodes added to the Sites tree by the specified scan. */
+    /**
+     * Returns a list of the names of the nodes added to the Sites tree by the specified scan.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse addedNodes(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         if (scanid != null) {
@@ -87,6 +101,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
     /**
      * Gets all the domains that are always in scope. For each domain the following are shown: the
      * index, the value (domain), if enabled, and if specified as a regex.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse domainsAlwaysInScope() throws ClientApiException {
         return api.callApi("spider", "view", "domainsAlwaysInScope", null);
@@ -94,6 +110,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
 
     /**
      * Use view domainsAlwaysInScope instead.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      *
      * @deprecated
      */
@@ -105,6 +123,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
     /**
      * Use view domainsAlwaysInScope instead.
      *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     *
      * @deprecated
      */
     @Deprecated
@@ -112,103 +132,127 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "view", "optionDomainsAlwaysInScopeEnabled", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionHandleParameters() throws ClientApiException {
         return api.callApi("spider", "view", "optionHandleParameters", null);
     }
 
-    /** Gets the maximum number of child nodes (per node) that can be crawled, 0 means no limit. */
+    /**
+     * Gets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse optionMaxChildren() throws ClientApiException {
         return api.callApi("spider", "view", "optionMaxChildren", null);
     }
 
-    /** Gets the maximum depth the spider can crawl, 0 if unlimited. */
+    /**
+     * Gets the maximum depth the spider can crawl, 0 if unlimited.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse optionMaxDepth() throws ClientApiException {
         return api.callApi("spider", "view", "optionMaxDepth", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionMaxDuration() throws ClientApiException {
         return api.callApi("spider", "view", "optionMaxDuration", null);
     }
 
-    /** Gets the maximum size, in bytes, that a response might have to be parsed. */
+    /**
+     * Gets the maximum size, in bytes, that a response might have to be parsed.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse optionMaxParseSizeBytes() throws ClientApiException {
         return api.callApi("spider", "view", "optionMaxParseSizeBytes", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionMaxScansInUI() throws ClientApiException {
         return api.callApi("spider", "view", "optionMaxScansInUI", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionRequestWaitTime() throws ClientApiException {
         return api.callApi("spider", "view", "optionRequestWaitTime", null);
     }
 
-    /** @deprecated Option no longer in effective use. */
-    @Deprecated
-    public ApiResponse optionScope() throws ClientApiException {
-        return api.callApi("spider", "view", "optionScope", null);
-    }
-
-    /** @deprecated Option no longer in effective use. */
-    @Deprecated
-    public ApiResponse optionScopeText() throws ClientApiException {
-        return api.callApi("spider", "view", "optionScopeText", null);
-    }
-
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionSkipURLString() throws ClientApiException {
         return api.callApi("spider", "view", "optionSkipURLString", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionThreadCount() throws ClientApiException {
         return api.callApi("spider", "view", "optionThreadCount", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionUserAgent() throws ClientApiException {
         return api.callApi("spider", "view", "optionUserAgent", null);
     }
 
-    /** Gets whether or not a spider process should accept cookies while spidering. */
+    /**
+     * Gets whether or not a spider process should accept cookies while spidering.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse optionAcceptCookies() throws ClientApiException {
         return api.callApi("spider", "view", "optionAcceptCookies", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionHandleODataParametersVisited() throws ClientApiException {
         return api.callApi("spider", "view", "optionHandleODataParametersVisited", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionParseComments() throws ClientApiException {
         return api.callApi("spider", "view", "optionParseComments", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionParseGit() throws ClientApiException {
         return api.callApi("spider", "view", "optionParseGit", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionParseRobotsTxt() throws ClientApiException {
         return api.callApi("spider", "view", "optionParseRobotsTxt", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionParseSVNEntries() throws ClientApiException {
         return api.callApi("spider", "view", "optionParseSVNEntries", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionParseSitemapXml() throws ClientApiException {
         return api.callApi("spider", "view", "optionParseSitemapXml", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionPostForm() throws ClientApiException {
         return api.callApi("spider", "view", "optionPostForm", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionProcessForm() throws ClientApiException {
         return api.callApi("spider", "view", "optionProcessForm", null);
     }
 
-    /** Gets whether or not the 'Referer' header should be sent while spidering. */
+    /**
+     * Gets whether or not the 'Referer' header should be sent while spidering.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse optionSendRefererHeader() throws ClientApiException {
         return api.callApi("spider", "view", "optionSendRefererHeader", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse optionShowAdvancedDialog() throws ClientApiException {
         return api.callApi("spider", "view", "optionShowAdvancedDialog", null);
     }
@@ -219,6 +263,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
      * prevent the spider from seeding recursively, the parameter 'contextName' can be used to
      * constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider
      * under a site's subtree (using the specified 'url').
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse scan(
             String url, String maxchildren, String recurse, String contextname, String subtreeonly)
@@ -245,6 +291,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
     /**
      * Runs the spider from the perspective of a User, obtained using the given Context ID and User
      * ID. See 'scan' action for more details.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse scanAsUser(
             String contextid,
@@ -272,18 +320,21 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "action", "scanAsUser", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse pause(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("scanId", scanid);
         return api.callApi("spider", "action", "pause", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse resume(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("scanId", scanid);
         return api.callApi("spider", "action", "resume", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse stop(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         if (scanid != null) {
@@ -292,34 +343,47 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "action", "stop", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse removeScan(String scanid) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("scanId", scanid);
         return api.callApi("spider", "action", "removeScan", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse pauseAllScans() throws ClientApiException {
         return api.callApi("spider", "action", "pauseAllScans", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse resumeAllScans() throws ClientApiException {
         return api.callApi("spider", "action", "resumeAllScans", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse stopAllScans() throws ClientApiException {
         return api.callApi("spider", "action", "stopAllScans", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse removeAllScans() throws ClientApiException {
         return api.callApi("spider", "action", "removeAllScans", null);
     }
 
-    /** Clears the regexes of URLs excluded from the spider scans. */
+    /**
+     * Clears the regexes of URLs excluded from the spider scans.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse clearExcludedFromScan() throws ClientApiException {
         return api.callApi("spider", "action", "clearExcludedFromScan", null);
     }
 
-    /** Adds a regex of URLs that should be excluded from the spider scans. */
+    /**
+     * Adds a regex of URLs that should be excluded from the spider scans.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse excludeFromScan(String regex) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("regex", regex);
@@ -330,6 +394,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
      * Adds a new domain that's always in scope, using the specified value. Optionally sets if the
      * new entry is enabled (default, true) and whether or not the new value is specified as a regex
      * (default, false).
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse addDomainAlwaysInScope(String value, String isregex, String isenabled)
             throws ClientApiException {
@@ -348,6 +414,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
      * Modifies a domain that's always in scope. Allows to modify the value, if enabled or if a
      * regex. The domain is selected with its index, which can be obtained with the view
      * domainsAlwaysInScope.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse modifyDomainAlwaysInScope(
             String idx, String value, String isregex, String isenabled) throws ClientApiException {
@@ -368,6 +436,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
     /**
      * Removes a domain that's always in scope, with the given index. The index can be obtained with
      * the view domainsAlwaysInScope.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse removeDomainAlwaysInScope(String idx) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -375,53 +445,57 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "action", "removeDomainAlwaysInScope", map);
     }
 
-    /** Enables all domains that are always in scope. */
+    /**
+     * Enables all domains that are always in scope.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse enableAllDomainsAlwaysInScope() throws ClientApiException {
         return api.callApi("spider", "action", "enableAllDomainsAlwaysInScope", null);
     }
 
-    /** Disables all domains that are always in scope. */
+    /**
+     * Disables all domains that are always in scope.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse disableAllDomainsAlwaysInScope() throws ClientApiException {
         return api.callApi("spider", "action", "disableAllDomainsAlwaysInScope", null);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionHandleParameters(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("spider", "action", "setOptionHandleParameters", map);
     }
 
-    /**
-     * Use actions [add|modify|remove]DomainAlwaysInScope instead.
-     *
-     * @deprecated Option no longer in effective use.
-     */
-    @Deprecated
-    public ApiResponse setOptionScopeString(String string) throws ClientApiException {
-        Map<String, String> map = new HashMap<>();
-        map.put("String", string);
-        return api.callApi("spider", "action", "setOptionScopeString", map);
-    }
-
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionSkipURLString(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("spider", "action", "setOptionSkipURLString", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionUserAgent(String string) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("String", string);
         return api.callApi("spider", "action", "setOptionUserAgent", map);
     }
 
-    /** Sets whether or not a spider process should accept cookies while spidering. */
+    /**
+     * Sets whether or not a spider process should accept cookies while spidering.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse setOptionAcceptCookies(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionAcceptCookies", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionHandleODataParametersVisited(boolean bool)
             throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -429,20 +503,29 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "action", "setOptionHandleODataParametersVisited", map);
     }
 
-    /** Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit. */
+    /**
+     * Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse setOptionMaxChildren(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));
         return api.callApi("spider", "action", "setOptionMaxChildren", map);
     }
 
-    /** Sets the maximum depth the spider can crawl, 0 for unlimited depth. */
+    /**
+     * Sets the maximum depth the spider can crawl, 0 for unlimited depth.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse setOptionMaxDepth(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));
         return api.callApi("spider", "action", "setOptionMaxDepth", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionMaxDuration(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));
@@ -452,6 +535,8 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
     /**
      * Sets the maximum size, in bytes, that a response might have to be parsed. This allows the
      * spider to skip big responses/files.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
      */
     public ApiResponse setOptionMaxParseSizeBytes(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
@@ -459,73 +544,88 @@ public class Spider extends org.zaproxy.clientapi.gen.deprecated.SpiderDeprecate
         return api.callApi("spider", "action", "setOptionMaxParseSizeBytes", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionMaxScansInUI(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));
         return api.callApi("spider", "action", "setOptionMaxScansInUI", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionParseComments(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionParseComments", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionParseGit(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionParseGit", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionParseRobotsTxt(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionParseRobotsTxt", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionParseSVNEntries(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionParseSVNEntries", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionParseSitemapXml(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionParseSitemapXml", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionPostForm(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionPostForm", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionProcessForm(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionProcessForm", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionRequestWaitTime(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));
         return api.callApi("spider", "action", "setOptionRequestWaitTime", map);
     }
 
-    /** Sets whether or not the 'Referer' header should be sent while spidering. */
+    /**
+     * Sets whether or not the 'Referer' header should be sent while spidering.
+     *
+     * <p>This component is optional and therefore the API will only work if it is installed
+     */
     public ApiResponse setOptionSendRefererHeader(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionSendRefererHeader", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionShowAdvancedDialog(boolean bool) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Boolean", Boolean.toString(bool));
         return api.callApi("spider", "action", "setOptionShowAdvancedDialog", map);
     }
 
+    /** This component is optional and therefore the API will only work if it is installed */
     public ApiResponse setOptionThreadCount(int i) throws ClientApiException {
         Map<String, String> map = new HashMap<>();
         map.put("Integer", Integer.toString(i));

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AcsrfDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AcsrfDeprecated.java
@@ -79,4 +79,14 @@ public class AcsrfDeprecated {
         map.put("hrefId", hrefid);
         return api.callApiOther("acsrf", "other", "genForm", map);
     }
+
+    /** Generate a form for testing lack of anti-CSRF tokens - typically invoked via ZAP */
+    public byte[] genFormWithUrl(String hrefid, String actionurl) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("hrefId", hrefid);
+        if (actionurl != null) {
+            map.put("actionUrl", actionurl);
+        }
+        return api.callApiOther("acsrf", "other", "genForm", map);
+    }
 }

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AscanDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/AscanDeprecated.java
@@ -449,6 +449,11 @@ public class AscanDeprecated {
         return api.callApi("ascan", "action", "addScanPolicy", map);
     }
 
+    @Deprecated
+    public ApiResponse addScanPolicy(String scanpolicyname) throws ClientApiException {
+        return addScanPolicy(scanpolicyname, null);
+    }
+
     /**
      * @deprecated (1.1.0) Use the method without the API key and use one of the {@code ClientApi}
      *     constructors that allow to set the API key (e.g. {@link ClientApi#ClientApi(String, int,

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ReplacerDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/ReplacerDeprecated.java
@@ -1,0 +1,63 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.clientapi.gen.deprecated;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** API implementation with deprecated methods, (re)moved from generated class. */
+@SuppressWarnings("javadoc")
+public class ReplacerDeprecated {
+
+    private final ClientApi api;
+
+    public ReplacerDeprecated(ClientApi api) {
+        this.api = api;
+    }
+
+    /** @deprecated (1.11.0) Use the method with the url. */
+    @Deprecated
+    public ApiResponse addRule(
+            String description,
+            String enabled,
+            String matchtype,
+            String matchregex,
+            String matchstring,
+            String replacement,
+            String initiators)
+            throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("description", description);
+        map.put("enabled", enabled);
+        map.put("matchType", matchtype);
+        map.put("matchRegex", matchregex);
+        map.put("matchString", matchstring);
+        if (replacement != null) {
+            map.put("replacement", replacement);
+        }
+        if (initiators != null) {
+            map.put("initiators", initiators);
+        }
+        return api.callApi("replacer", "action", "addRule", map);
+    }
+}

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SpiderDeprecated.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen/deprecated/SpiderDeprecated.java
@@ -548,4 +548,28 @@ public class SpiderDeprecated {
         map.put("Integer", Integer.toString(i));
         return api.callApi("spider", "action", "setOptionThreadCount", map);
     }
+
+    /** @deprecated Option no longer in effective use. */
+    @Deprecated
+    public ApiResponse optionScope() throws ClientApiException {
+        return api.callApi("spider", "view", "optionScope", null);
+    }
+
+    /** @deprecated Option no longer in effective use. */
+    @Deprecated
+    public ApiResponse optionScopeText() throws ClientApiException {
+        return api.callApi("spider", "view", "optionScopeText", null);
+    }
+
+    /**
+     * Use actions [add|modify|remove]DomainAlwaysInScope instead.
+     *
+     * @deprecated Option no longer in effective use.
+     */
+    @Deprecated
+    public ApiResponse setOptionScopeString(String string) throws ClientApiException {
+        Map<String, String> map = new HashMap<>();
+        map.put("String", string);
+        return api.callApi("spider", "action", "setOptionScopeString", map);
+    }
 }

--- a/subprojects/zap-clientapi/zap-clientapi.gradle
+++ b/subprojects/zap-clientapi/zap-clientapi.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "maven-publish"
     id "signing"
-    id "me.champeau.gradle.japicmp" version "0.2.9"
+    id "me.champeau.gradle.japicmp" version "0.4.1"
 }
 
 sourceSets { examples }
@@ -41,13 +41,15 @@ task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
     group 'verification'
     description "Checks artifacts' binary compatibility with latest (released) version '$versionBC'."
 
-    oldClasspath = files(clientapiJar(versionBC))
-    newClasspath = files(tasks.named(JavaPlugin.JAR_TASK_NAME).map { it.archivePath })
-    onlyBinaryIncompatibleModified = true
-    failOnModification = true
-    ignoreMissingClasses = true
-    htmlOutputFile = file("$buildDir/reports/japi.html")
+    oldClasspath.from(files(clientapiJar(versionBC)))
+    newClasspath.from(files(tasks.named(JavaPlugin.JAR_TASK_NAME).map { it.archivePath }))
+    onlyBinaryIncompatibleModified.set(true)
+    failOnModification.set(true)
+    ignoreMissingClasses.set(true)
+    htmlOutputFile.set(file("$buildDir/reports/japi.html"))
 }
+
+check.dependsOn(japicmp)
 
 task javadocJar(type: Jar) {
     classifier = 'javadoc'


### PR DESCRIPTION
Update core APIs for 2.12.0.

Add the APIs of the following add-ons:
 - Import/Export version 0.3.0;
 - Network version 0.3.0;
 - Spider version 0.1.0.

Update the API of the following add-on:
 - Replacer version 11.

Deprecate the following APIs:
 - `ImportLogFiles`;
 - `Importurls`;
 - `LocalProxies`.

Update Gradle Plugin for japicmp.