### PR TITLE
Stop sending API key as query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop sending the API key as query parameter, not needed since ZAP 2.6.0.
+
 ### Deprecated
 - The following APIs were deprecated:
   - `Exportreport`

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -92,7 +92,6 @@ public class ClientApi {
     private static final int DEFAULT_CONNECTION_POOLING_IN_MS = 1000;
 
     private static final String ZAP_API_KEY_HEADER = "X-ZAP-API-Key";
-    private static final String ZAP_API_KEY_PARAM = "apikey";
 
     private Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8090));
     private boolean debug = false;
@@ -486,10 +485,6 @@ public class ClientApi {
         sb.append(method);
         sb.append('/');
         if (params != null) {
-            if (apiKey != null && !apiKey.isEmpty()) {
-                params.put(ZAP_API_KEY_PARAM, apiKey);
-            }
-
             sb.append('?');
             for (Map.Entry<String, String> p : params.entrySet()) {
                 sb.append(encodeQueryParam(p.getKey()));
@@ -499,13 +494,6 @@ public class ClientApi {
                 }
                 sb.append('&');
             }
-        } else if (apiKey != null && !apiKey.isEmpty()) {
-            // Send the API key even if there are no parameters,
-            // older ZAP versions might need it as (query) parameter.
-            sb.append('?');
-            sb.append(encodeQueryParam(ZAP_API_KEY_PARAM));
-            sb.append('=');
-            sb.append(encodeQueryParam(apiKey));
         }
 
         HttpRequest request = new HttpRequest(createUrl(sb.toString()));


### PR DESCRIPTION
Send only as an HTTP header, which is supported by ZAP since 2.6.0.