### PR TITLE
Add method to get JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add support for JSON API calls with new method callApiJson
 
 ## [1.15.0] - 2025-01-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add support for JSON API calls with new method callApiJson
+### Added
+- Add support for JSON API calls with new method `callApiJson`.
 
 ## [1.15.0] - 2025-01-20
 ### Added

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -475,13 +475,11 @@ public class ClientApi {
         return getBytes(requestMethod, "other", component, type, method, params);
     }
 
-    public byte[] callApiJSON(
-            String component,
-            String type,
-            String method,
-            Map<String, String> params)
+    public String callApiJson(
+            String component, String type, String method, Map<String, String> params)
             throws ClientApiException {
-        return getBytes(HttpRequest.GET_METHOD, "JSON", component, type, method, params);
+        byte[] json = getBytes(HttpRequest.GET_METHOD, "JSON", component, type, method, params);
+        return new String(json, StandardCharsets.UTF_8);
     }
 
     private byte[] getBytes(

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -476,13 +476,12 @@ public class ClientApi {
     }
 
     public byte[] callApiJSON(
-            String requestMethod,
             String component,
             String type,
             String method,
             Map<String, String> params)
             throws ClientApiException {
-        return getBytes(requestMethod, "JSON", component, type, method, params);
+        return getBytes(HttpRequest.GET_METHOD, "JSON", component, type, method, params);
     }
 
     private byte[] getBytes(

--- a/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
+++ b/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/core/ClientApi.java
@@ -472,9 +472,30 @@ public class ClientApi {
             String method,
             Map<String, String> params)
             throws ClientApiException {
+        return getBytes(requestMethod, "other", component, type, method, params);
+    }
+
+    public byte[] callApiJSON(
+            String requestMethod,
+            String component,
+            String type,
+            String method,
+            Map<String, String> params)
+            throws ClientApiException {
+        return getBytes(requestMethod, "JSON", component, type, method, params);
+    }
+
+    private byte[] getBytes(
+            String requestMethod,
+            String format,
+            String component,
+            String type,
+            String method,
+            Map<String, String> params)
+            throws ClientApiException {
         try {
             HttpRequest request =
-                    buildZapRequest(requestMethod, "other", component, type, method, params);
+                    buildZapRequest(requestMethod, format, component, type, method, params);
             if (debug) {
                 debugStream.println("Open URL: " + request.getRequestUri());
             }


### PR DESCRIPTION
Add support for JSON API calls with new method callApiJson.

Background:
There are some API methods (e.g. alert/view/alertCountsByRisk) which only work with JSON as the requested response format. Not using JSON (this is a different bug) will result in an "Internal Error" (e.g. Alert#alertCountsByRisk(String, String)).
The new method callApiJson allows java client API users to request a JSON response. We now also can create/build JSON models (e.g. with/for GSON) further enhancing the APIs usability.